### PR TITLE
fix: restore SET parameter count fallback

### DIFF
--- a/src/main/java/com/jfeatures/msg/codegen/dbmetadata/UpdateMetadataExtractor.java
+++ b/src/main/java/com/jfeatures/msg/codegen/dbmetadata/UpdateMetadataExtractor.java
@@ -171,7 +171,16 @@ public class UpdateMetadataExtractor {
         } catch (JSQLParserException e) {
             log.warn("Could not parse UPDATE to count SET params: {}", e.getMessage());
         }
-        return 0;
+
+        // Fallback: best effort by counting '?' in the SET clause
+        String upperSql = sql.toUpperCase();
+        int setIndex = upperSql.indexOf("SET");
+        if (setIndex == -1) {
+            return 0;
+        }
+        int whereIndex = upperSql.indexOf("WHERE", setIndex);
+        String setClause = whereIndex == -1 ? sql.substring(setIndex) : sql.substring(setIndex, whereIndex);
+        return (int) setClause.chars().filter(ch -> ch == '?').count();
     }
     
     /**


### PR DESCRIPTION
## Summary
- restore '?' fallback for counting SET parameters when UPDATE parsing fails

## Testing
- `mvn -q -e test` *(fails: Plugin org.springframework.boot:spring-boot-maven-plugin:3.3.4: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdca125470832a9876aecd6a960439