### PR TITLE
Add SonarCloud cleanup plan and utility class fix

### DIFF
--- a/docs/sonarcloud-issues-plan.md
+++ b/docs/sonarcloud-issues-plan.md
@@ -1,0 +1,18 @@
+# SonarCloud Cleanup Tasks
+
+## Security Hotspots
+- Review and optimize regex patterns in:
+  - `ParameterMetadataExtractor.java` line ~87
+  - `DeleteMicroserviceGenerator.java` line ~111
+
+## Code Smells
+- Replace usages of `@Deprecated` methods marked for removal.
+- Consolidate runtime exception tests to a single invocation.
+- Extract duplicate string literals into constants.
+- Remove superfluous exceptions in `throws` clauses.
+- Ensure utility classes have private constructors (e.g., `TestUtils`).
+- Group similar tests using parameterized tests.
+- Chain consecutive AssertJ `assertThat` statements.
+- Remove unused local variables and assignments.
+- Drop unused method parameters or annotate appropriately.
+

--- a/src/main/java/com/jfeatures/msg/codegen/generator/DeleteMicroserviceGenerator.java
+++ b/src/main/java/com/jfeatures/msg/codegen/generator/DeleteMicroserviceGenerator.java
@@ -107,8 +107,11 @@ public class DeleteMicroserviceGenerator {
             tableName = afterFrom.trim();
         }
         
-        // Remove any trailing semicolon or whitespace
-        tableName = tableName.replaceAll("[;\\s]+$", "");
+        // Remove any trailing semicolon or whitespace without regex
+        tableName = tableName.trim();
+        while (tableName.endsWith(";")) {
+            tableName = tableName.substring(0, tableName.length() - 1).trim();
+        }
         
         return tableName;
     }

--- a/src/main/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuilders.java
+++ b/src/main/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuilders.java
@@ -207,32 +207,4 @@ public class CommonJavaPoetBuilders {
                 .build();
     }
     
-    // =========================== UTILITY METHODS ===========================
-    
-    /**
-     * Creates a standard package name for generated classes.
-     * @deprecated Use {@link NamingConventions#buildPackageName(String, String)} instead
-     */
-    @Deprecated(since = "2.0", forRemoval = true)
-    public static String buildPackageName(String businessName, String packageSuffix) {
-        return NamingConventions.buildPackageName(businessName, packageSuffix);
-    }
-    
-    /**
-     * Creates a standard class name for generated classes.
-     * @deprecated Use {@link NamingConventions#buildClassName(String, String)} instead
-     */
-    @Deprecated(since = "2.0", forRemoval = true)
-    public static String buildClassName(String businessName, String classSuffix) {
-        return NamingConventions.buildClassName(businessName, classSuffix);
-    }
-    
-    /**
-     * Creates a field name for JDBC template following naming conventions.
-     * @deprecated Use {@link NamingConventions#jdbcTemplateFieldName(String)} instead
-     */
-    @Deprecated(since = "2.0", forRemoval = true)
-    public static String jdbcTemplateFieldName(String businessName) {
-        return NamingConventions.jdbcTemplateFieldName(businessName);
-    }
 }

--- a/src/test/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuildersTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuildersTest.java
@@ -4,13 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.squareup.javapoet.*;
-import java.util.stream.Stream;
 import javax.lang.model.element.Modifier;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
@@ -282,73 +278,10 @@ class CommonJavaPoetBuildersTest {
         assertThat(param.annotations.get(0).type).isEqualTo(ClassName.get(PathVariable.class));
     }
 
-    // ============================= UTILITY METHOD TESTS ==============================
-
-    @ParameterizedTest
-    @MethodSource("provideBusinessNameAndPackageSuffixArguments")
-    void shouldBuildPackageName(String businessName, String packageSuffix, String expectedPackage) {
-        // When
-        String result = CommonJavaPoetBuilders.buildPackageName(businessName, packageSuffix);
-        
-        // Then
-        assertThat(result).isEqualTo(expectedPackage);
-    }
-
-    static Stream<Arguments> provideBusinessNameAndPackageSuffixArguments() {
-        return Stream.of(
-            Arguments.of("Customer", "dao", "com.jfeatures.msg.customer.dao"),
-            Arguments.of("OrderDetail", "dto", "com.jfeatures.msg.orderdetail.dto"),
-            Arguments.of("USER", "controller", "com.jfeatures.msg.user.controller"),
-            Arguments.of("Product", "service", "com.jfeatures.msg.product.service")
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideBusinessNameAndClassSuffixArguments")
-    void shouldBuildClassName(String businessName, String classSuffix, String expectedClassName) {
-        // When
-        String result = CommonJavaPoetBuilders.buildClassName(businessName, classSuffix);
-        
-        // Then
-        assertThat(result).isEqualTo(expectedClassName);
-    }
-
-    static Stream<Arguments> provideBusinessNameAndClassSuffixArguments() {
-        return Stream.of(
-            Arguments.of("Customer", "DAO", "CustomerDAO"),
-            Arguments.of("OrderDetail", "DTO", "OrderDetailDTO"),
-            Arguments.of("User", "Controller", "UserController"),
-            Arguments.of("Product", "Service", "ProductService")
-        );
-    }
-
-    @Test
-    void shouldCreateJdbcTemplateFieldName() {
-        // When
-        String result = CommonJavaPoetBuilders.jdbcTemplateFieldName("Customer");
-        
-        // Then
-        assertThat(result).isEqualTo("customerNamedParameterJdbcTemplate");
-    }
-
     @Test
     void shouldHandleNullInputsGracefully() {
         // Test null field name - this should throw NPE
-        assertThrows(NullPointerException.class, () -> 
+        assertThrows(NullPointerException.class, () ->
             CommonJavaPoetBuilders.jdbcTemplateField(null));
-        
-        // Note: buildPackageName with null inputs may not throw NPE if the underlying 
-        // string concatenation handles nulls gracefully, which is acceptable behavior
-    }
-
-    @Test
-    void shouldHandleEmptyInputsCorrectly() {
-        // Empty business name should still work
-        String result = CommonJavaPoetBuilders.buildPackageName("", "dao");
-        assertThat(result).isEqualTo("com.jfeatures.msg..dao");
-        
-        // Empty class suffix should still work
-        String className = CommonJavaPoetBuilders.buildClassName("Customer", "");
-        assertThat(className).isEqualTo("Customer");
     }
 }

--- a/src/test/java/com/jfeatures/msg/test/TestUtils.java
+++ b/src/test/java/com/jfeatures/msg/test/TestUtils.java
@@ -20,8 +20,12 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 /**
  * Utility class for test data creation and mock setup
  */
-public class TestUtils {
-    
+public final class TestUtils {
+
+    private TestUtils() {
+        // prevents instantiation
+    }
+
     /**
      * Creates a ColumnMetadata object with proper initialization for testing
      */


### PR DESCRIPTION
## Summary
- document tasks for resolving SonarCloud security hotspots and code smells
- make TestUtils non-instantiable to address Sonar issue S1118
- remove deprecated builder helpers and replace risky regex usage

## Testing
- `mvn -q test` *(fails: Plugin org.springframework.boot:spring-boot-maven-plugin:pom:3.3.4 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be7dfd23ec832a83cd4d4ed842e31e