### PR TITLE
fix: allow CTE and comment-prefixed queries in SQL validation

### DIFF
--- a/src/test/java/com/jfeatures/msg/codegen/dbmetadata/SqlMetadataTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/dbmetadata/SqlMetadataTest.java
@@ -211,6 +211,54 @@ class SqlMetadataTest {
         assertEquals("customer_name", secondColumn.getColumnName());
         assertEquals("name", secondColumn.getColumnAlias());
     }
+
+    @Test
+    void testGetColumnMetadata_CteQuery_AcceptsWithClause() throws SQLException {
+        String query = """
+            WITH cte AS (SELECT 1 AS id)
+            SELECT id FROM cte
+            """;
+
+        setupSingleColumnResultSetMetadata();
+
+        when(jdbcTemplate.query(eq(query), any(RowMapper.class))).thenAnswer(invocation -> {
+            RowMapper<ColumnMetadata> rowMapper = invocation.getArgument(1);
+
+            when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+            rowMapper.mapRow(resultSet, 0);
+
+            return null;
+        });
+
+        List<ColumnMetadata> result = sqlMetadata.getColumnMetadata(query);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testGetColumnMetadata_QueryWithLeadingComment_Allowed() throws SQLException {
+        String query = """
+            -- fetch customer ids
+            SELECT customer_id FROM customers
+            """;
+
+        setupSingleColumnResultSetMetadata();
+
+        when(jdbcTemplate.query(eq(query), any(RowMapper.class))).thenAnswer(invocation -> {
+            RowMapper<ColumnMetadata> rowMapper = invocation.getArgument(1);
+
+            when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+            rowMapper.mapRow(resultSet, 0);
+
+            return null;
+        });
+
+        List<ColumnMetadata> result = sqlMetadata.getColumnMetadata(query);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
     
     @Test
     void testGetColumnMetadata_SQLException_PropagatesException() throws SQLException {


### PR DESCRIPTION
## Summary
- allow common table expressions and leading comments in SQL validation
- filter SQL comments prior to structure checks
- add tests for CTE and comment-prefixed queries

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-maven-plugin:pom:3.3.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `mvn -q -o test` *(fails: Cannot access central (https://repo.maven.apache.org/maven2) in offline mode and the artifact ... has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1db13c18832aa84d3f2682be5118