### PR TITLE
Fix Sonar S5853 violations in AssertJ tests

### DIFF
--- a/src/test/java/com/jfeatures/msg/codegen/GenerateControllerTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateControllerTest.java
@@ -26,13 +26,14 @@ class GenerateControllerTest {
         assertThat(result.typeSpec.name).isEqualTo("CustomerController");
         
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("@RestController");
-        assertThat(generatedCode).contains("path = \"/api\"");
-        assertThat(generatedCode).contains("name = \"Customer\"");
-        assertThat(generatedCode).contains("description = \"Customer\"");
-        assertThat(generatedCode).contains("getDataForCustomer");
-        assertThat(generatedCode).contains("value = \"/Customer\"");
-        assertThat(generatedCode).contains("produces = \"application/json\"");
+        assertThat(generatedCode)
+            .contains("@RestController")
+            .contains("path = \"/api\"")
+            .contains("name = \"Customer\"")
+            .contains("description = \"Customer\"")
+            .contains("getDataForCustomer")
+            .contains("value = \"/Customer\"")
+            .contains("produces = \"application/json\"");
     }
 
     @Test
@@ -49,10 +50,11 @@ class GenerateControllerTest {
 
         // Then
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("@RequestParam(\"customerid\") Integer customerid");
-        assertThat(generatedCode).contains("@RequestParam(\"status\") String status");
-        assertThat(generatedCode).contains("@RequestParam(\"minamount\") BigDecimal minamount");
-        assertThat(generatedCode).contains("return orderDAO.getOrder(customerid, status, minamount)");
+        assertThat(generatedCode)
+            .contains("@RequestParam(\"customerid\") Integer customerid")
+            .contains("@RequestParam(\"status\") String status")
+            .contains("@RequestParam(\"minamount\") BigDecimal minamount")
+            .contains("return orderDAO.getOrder(customerid, status, minamount)");
     }
 
     @Test
@@ -65,9 +67,10 @@ class GenerateControllerTest {
 
         // Then
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("getDataForAllCustomers()");
-        assertThat(generatedCode).contains("return allcustomersDAO.getAllCustomers()");
-        assertThat(generatedCode).contains("List<AllCustomersDTO>");
+        assertThat(generatedCode)
+            .contains("getDataForAllCustomers()")
+            .contains("return allcustomersDAO.getAllCustomers()")
+            .contains("List<AllCustomersDTO>");
     }
 
     @Test
@@ -82,9 +85,10 @@ class GenerateControllerTest {
 
         // Then
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("summary = \"Get API to fetch data for Product\"");
-        assertThat(generatedCode).contains("name = \"Product\"");
-        assertThat(generatedCode).contains("description = \"Product\"");
+        assertThat(generatedCode)
+            .contains("summary = \"Get API to fetch data for Product\"")
+            .contains("name = \"Product\"")
+            .contains("description = \"Product\"");
     }
 
     @Test
@@ -103,9 +107,10 @@ class GenerateControllerTest {
         assertThat(result.packageName).isEqualTo("com.jfeatures.msg.quarterlysalesreport.controller");
         
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("getDataForQuarterlySalesReport");
-        assertThat(generatedCode).contains("quarterlysalesreportDAO.getQuarterlySalesReport");
-        assertThat(generatedCode).contains("List<QuarterlySalesReportDTO>");
+        assertThat(generatedCode)
+            .contains("getDataForQuarterlySalesReport")
+            .contains("quarterlysalesreportDAO.getQuarterlySalesReport")
+            .contains("List<QuarterlySalesReportDTO>");
     }
 
     @Test
@@ -120,9 +125,10 @@ class GenerateControllerTest {
 
         // Then
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("private final UserDAO userDAO");
-        assertThat(generatedCode).contains("UserController(UserDAO userDAO)");
-        assertThat(generatedCode).contains("this.userDAO = userDAO");
+        assertThat(generatedCode)
+            .contains("private final UserDAO userDAO")
+            .contains("UserController(UserDAO userDAO)")
+            .contains("this.userDAO = userDAO");
     }
 
     @Test
@@ -138,9 +144,10 @@ class GenerateControllerTest {
 
         // Then
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("@RequestParam(\"user_id\") Integer user_id");
-        assertThat(generatedCode).contains("@RequestParam(\"created_date\") Date created_date");
-        assertThat(generatedCode).contains("return useractivityDAO.getUserActivity(user_id, created_date)");
+        assertThat(generatedCode)
+            .contains("@RequestParam(\"user_id\") Integer user_id")
+            .contains("@RequestParam(\"created_date\") Date created_date")
+            .contains("return useractivityDAO.getUserActivity(user_id, created_date)");
     }
 
     @Test

--- a/src/test/java/com/jfeatures/msg/codegen/GenerateDTOTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateDTOTest.java
@@ -31,11 +31,12 @@ class GenerateDTOTest {
         assertThat(result.typeSpec.name).isEqualTo("CustomerDTO");
         
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("@Builder");
-        assertThat(generatedCode).contains("@Value");
-        assertThat(generatedCode).contains("@Jacksonized");
-        assertThat(generatedCode).contains("public Integer id;");
-        assertThat(generatedCode).contains("public String name;");
+        assertThat(generatedCode)
+            .contains("@Builder")
+            .contains("@Value")
+            .contains("@Jacksonized")
+            .contains("public Integer id;")
+            .contains("public String name;");
     }
 
     @Test
@@ -51,8 +52,9 @@ class GenerateDTOTest {
 
         // Then
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("public Integer userId;");
-        assertThat(generatedCode).contains("public Timestamp createdAt;");
+        assertThat(generatedCode)
+            .contains("public Integer userId;")
+            .contains("public Timestamp createdAt;");
     }
 
     @Test
@@ -115,10 +117,11 @@ class GenerateDTOTest {
 
         // Then
         String generatedCode = result.toString();
-        assertThat(generatedCode).contains("public Long id;");
-        assertThat(generatedCode).contains("public BigDecimal price;");
-        assertThat(generatedCode).contains("public Boolean active;");
-        assertThat(generatedCode).contains("public Date createdDate;");
+        assertThat(generatedCode)
+            .contains("public Long id;")
+            .contains("public BigDecimal price;")
+            .contains("public Boolean active;")
+            .contains("public Date createdDate;");
     }
 
     @Test

--- a/src/test/java/com/jfeatures/msg/codegen/GenerateDatabaseConfigTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateDatabaseConfigTest.java
@@ -17,12 +17,13 @@ class GenerateDatabaseConfigTest {
         String result = GenerateDatabaseConfig.createDatabaseConfig("Customer");
 
         // Then
-        assertThat(result).isNotNull();
-        assertThat(result).contains("@Configuration");
-        assertThat(result).contains("DatabaseConfig");
-        assertThat(result).contains("@Bean");
-        assertThat(result).contains("DataSource");
-        assertThat(result).contains("NamedParameterJdbcTemplate");
+        assertThat(result)
+            .isNotNull()
+            .contains("@Configuration")
+            .contains("DatabaseConfig")
+            .contains("@Bean")
+            .contains("DataSource")
+            .contains("NamedParameterJdbcTemplate");
     }
 
     @Test
@@ -32,8 +33,9 @@ class GenerateDatabaseConfigTest {
 
         // Then
         // The generated config uses ConfigurationProperties, so it doesn't hard-code the URL
-        assertThat(result).contains("@ConfigurationProperties(\"spring.datasource\")");
-        assertThat(result).contains("DataSourceBuilder.create().build()");
+        assertThat(result)
+            .contains("@ConfigurationProperties(\"spring.datasource\")")
+            .contains("DataSourceBuilder.create().build()");
     }
 
     // New tests to improve coverage

--- a/src/test/java/com/jfeatures/msg/codegen/MicroServiceGeneratorTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/MicroServiceGeneratorTest.java
@@ -39,10 +39,11 @@ class MicroServiceGeneratorTest {
         // Then
         assertThat(exitCode).isEqualTo(0);
         String output = outContent.toString() + errContent.toString();
-        assertThat(output).contains("Creates a microservice application");
-        assertThat(output).contains("-d, --destination");
-        assertThat(output).contains("-n, --name");
-        assertThat(output).contains("-f, --sql-file");
+        assertThat(output)
+            .contains("Creates a microservice application")
+            .contains("-d, --destination")
+            .contains("-n, --name")
+            .contains("-f, --sql-file");
     }
 
     @Test
@@ -117,9 +118,12 @@ class MicroServiceGeneratorTest {
         cmd.parseArgs("--destination", tempDir.toString(), "--name", "TestService", "--sql-file", "test.sql");
 
         // Then
-        assertThat(cmd.getParseResult().hasMatchedOption("destination")).isTrue();
-        assertThat(cmd.getParseResult().hasMatchedOption("name")).isTrue();
-        assertThat(cmd.getParseResult().hasMatchedOption("sql-file")).isTrue();
+        assertThat(cmd.getParseResult())
+            .satisfies(parseResult -> {
+                assertThat(parseResult.hasMatchedOption("destination")).isTrue();
+                assertThat(parseResult.hasMatchedOption("name")).isTrue();
+                assertThat(parseResult.hasMatchedOption("sql-file")).isTrue();
+            });
     }
 
     @Test
@@ -155,9 +159,12 @@ class MicroServiceGeneratorTest {
         cmd.parseArgs("-d", tempDir.toString(), "-n", "Customer", "-f", "customer.sql");
 
         // Then
-        assertThat(cmd.getParseResult().hasMatchedOption('d')).isTrue();
-        assertThat(cmd.getParseResult().hasMatchedOption('n')).isTrue();
-        assertThat(cmd.getParseResult().hasMatchedOption('f')).isTrue();
+        assertThat(cmd.getParseResult())
+            .satisfies(parseResult -> {
+                assertThat(parseResult.hasMatchedOption('d')).isTrue();
+                assertThat(parseResult.hasMatchedOption('n')).isTrue();
+                assertThat(parseResult.hasMatchedOption('f')).isTrue();
+            });
     }
 
     @Test

--- a/src/test/java/com/jfeatures/msg/codegen/util/ClassBuildersTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/ClassBuildersTest.java
@@ -40,8 +40,9 @@ class ClassBuildersTest {
             .anyMatch(a -> a.type.toString().contains("Slf4j"))).isTrue();
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("Data Access Object for customer operations");
-        assertThat(typeSpec.javadoc.toString()).contains("Follows single responsibility principle");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("Data Access Object for customer operations")
+            .contains("Follows single responsibility principle");
     }
 
     @Test
@@ -85,8 +86,9 @@ class ClassBuildersTest {
             .anyMatch(a -> a.type.toString().contains("Slf4j"))).isTrue();
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("Data Access Object for customer insert operations");
-        assertThat(typeSpec.javadoc.toString()).contains("Follows single responsibility principle - insert operations only");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("Data Access Object for customer insert operations")
+            .contains("Follows single responsibility principle - insert operations only");
     }
 
     @ParameterizedTest
@@ -98,7 +100,8 @@ class ClassBuildersTest {
         
         // Then
         assertThat(typeSpec.name).isEqualTo(expectedClassName);
-        assertThat(typeSpec.javadoc.toString()).contains(businessName.toLowerCase() + " " + operation.toLowerCase() + " operations");
+        assertThat(typeSpec.javadoc.toString())
+            .contains(businessName.toLowerCase() + " " + operation.toLowerCase() + " operations");
     }
 
     static Stream<Arguments> provideOperationDAOTestArguments() {
@@ -148,8 +151,9 @@ class ClassBuildersTest {
             .anyMatch(a -> a.type.toString().contains("Tag"))).isTrue();
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("REST Controller for customer operations");
-        assertThat(typeSpec.javadoc.toString()).contains("Provides HTTP endpoints for data access");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("REST Controller for customer operations")
+            .contains("Provides HTTP endpoints for data access");
     }
 
     @Test
@@ -189,8 +193,9 @@ class ClassBuildersTest {
         assertThat(typeSpec.annotations).hasSize(3); // RestController, RequestMapping, Tag
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("REST Controller for customer insert operations");
-        assertThat(typeSpec.javadoc.toString()).contains("Follows single responsibility principle - insert operations only");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("REST Controller for customer insert operations")
+            .contains("Follows single responsibility principle - insert operations only");
     }
 
     @Test
@@ -242,8 +247,9 @@ class ClassBuildersTest {
             .anyMatch(a -> a.type.toString().contains("Jacksonized"))).isTrue();
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("Data Transfer Object for customer");
-        assertThat(typeSpec.javadoc.toString()).contains("Immutable class with builder pattern support");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("Data Transfer Object for customer")
+            .contains("Immutable class with builder pattern support");
     }
 
     @Test
@@ -272,8 +278,9 @@ class ClassBuildersTest {
         assertThat(typeSpec.annotations).hasSize(3); // Builder, Value, Jacksonized
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("Data Transfer Object for customer create operations");
-        assertThat(typeSpec.javadoc.toString()).contains("Immutable class with builder pattern support");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("Data Transfer Object for customer create operations")
+            .contains("Immutable class with builder pattern support");
     }
 
     @Test
@@ -302,8 +309,9 @@ class ClassBuildersTest {
         assertThat(typeSpec.annotations).isEmpty(); // No Lombok annotations for POJO
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("Data Transfer Object for customer");
-        assertThat(typeSpec.javadoc.toString()).contains("Standard POJO implementation due to field count limitations");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("Data Transfer Object for customer")
+            .contains("Standard POJO implementation due to field count limitations");
     }
 
     @Test
@@ -336,8 +344,9 @@ class ClassBuildersTest {
             .anyMatch(a -> a.type.toString().contains("Configuration"))).isTrue();
         
         // Check JavaDoc
-        assertThat(typeSpec.javadoc.toString()).contains("Configuration class for database");
-        assertThat(typeSpec.javadoc.toString()).contains("Defines beans and configuration settings");
+        assertThat(typeSpec.javadoc.toString())
+            .contains("Configuration class for database")
+            .contains("Defines beans and configuration settings");
     }
 
     @Test
@@ -364,8 +373,10 @@ class ClassBuildersTest {
         Exception exception = assertThrows(Exception.class, constructor::newInstance);
         
         // The actual exception will be InvocationTargetException wrapping UnsupportedOperationException
-        assertThat(exception.getCause()).isInstanceOf(UnsupportedOperationException.class);
-        assertThat(exception.getCause().getMessage()).contains("This is a utility class and cannot be instantiated");
+        Throwable cause = exception.getCause();
+        assertThat(cause)
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("This is a utility class and cannot be instantiated");
     }
 
     // ============================= EDGE CASE TESTS ===================================

--- a/src/test/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuildersTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuildersTest.java
@@ -73,8 +73,9 @@ class CommonJavaPoetBuildersTest {
         assertThat(constructor.isConstructor()).isTrue();
         assertThat(constructor.modifiers).contains(Modifier.PUBLIC);
         assertThat(constructor.parameters).hasSize(1);
-        assertThat(constructor.parameters.get(0).type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
-        assertThat(constructor.parameters.get(0).name).isEqualTo("jdbcTemplate");
+        ParameterSpec parameter = constructor.parameters.get(0);
+        assertThat(parameter.type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
+        assertThat(parameter.name).isEqualTo("jdbcTemplate");
         
         // Check the constructor body contains assignment
         String codeString = constructor.code.toString();
@@ -90,19 +91,20 @@ class CommonJavaPoetBuildersTest {
         assertThat(constructor.isConstructor()).isTrue();
         assertThat(constructor.modifiers).contains(Modifier.PUBLIC);
         assertThat(constructor.parameters).hasSize(2);
-        
-        // Check DataSource parameter
-        assertThat(constructor.parameters.get(0).type).isEqualTo(TypeName.get(DataSource.class));
-        assertThat(constructor.parameters.get(0).name).isEqualTo("dataSource");
-        
-        // Check JdbcTemplate parameter
-        assertThat(constructor.parameters.get(1).type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
-        assertThat(constructor.parameters.get(1).name).isEqualTo("jdbcTemplate");
+
+        ParameterSpec dataSourceParam = constructor.parameters.get(0);
+        assertThat(dataSourceParam.type).isEqualTo(TypeName.get(DataSource.class));
+        assertThat(dataSourceParam.name).isEqualTo("dataSource");
+
+        ParameterSpec jdbcTemplateParam = constructor.parameters.get(1);
+        assertThat(jdbcTemplateParam.type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
+        assertThat(jdbcTemplateParam.name).isEqualTo("jdbcTemplate");
         
         // Check both assignments are present
         String codeString = constructor.code.toString();
-        assertThat(codeString).contains("this.dataSource = dataSource");
-        assertThat(codeString).contains("this.jdbcTemplate = jdbcTemplate");
+        assertThat(codeString)
+            .contains("this.dataSource = dataSource")
+            .contains("this.jdbcTemplate = jdbcTemplate");
     }
 
     // ============================= CLASS BUILDER TESTS ===============================

--- a/src/test/java/com/jfeatures/msg/codegen/util/FieldBuildersTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/FieldBuildersTest.java
@@ -116,9 +116,10 @@ class FieldBuildersTest {
         FieldSpec field = FieldBuilders.sqlField(multiLineSql, "SELECT_SQL");
         
         // Then
-        assertThat(field.initializer.toString()).contains("SELECT c.id, c.name, c.email");
-        assertThat(field.initializer.toString()).contains("FROM customer c");
-        assertThat(field.initializer.toString()).contains("WHERE c.id = :id");
+        assertThat(field.initializer.toString())
+            .contains("SELECT c.id, c.name, c.email")
+            .contains("FROM customer c")
+            .contains("WHERE c.id = :id");
     }
 
     @Test
@@ -186,8 +187,9 @@ class FieldBuildersTest {
         assertThat(field.name).isEqualTo(expectedFieldName);
         assertThat(field.type).isEqualTo(TypeName.get(expectedType));
         assertThat(field.modifiers).containsExactlyInAnyOrder(Modifier.PRIVATE);
-        assertThat(field.javadoc.toString()).contains("Database column: " + columnName);
-        assertThat(field.javadoc.toString()).contains("Type: " + columnType);
+        assertThat(field.javadoc.toString())
+            .contains("Database column: " + columnName)
+            .contains("Type: " + columnType);
     }
 
     static Stream<Arguments> provideDtoFieldArguments() {
@@ -339,8 +341,10 @@ class FieldBuildersTest {
         Exception exception = assertThrows(Exception.class, constructor::newInstance);
         
         // The actual exception will be InvocationTargetException wrapping UnsupportedOperationException
-        assertThat(exception.getCause()).isInstanceOf(UnsupportedOperationException.class);
-        assertThat(exception.getCause().getMessage()).contains("This is a utility class and cannot be instantiated");
+        Throwable cause = exception.getCause();
+        assertThat(cause)
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("This is a utility class and cannot be instantiated");
     }
 
     // ============================= HELPER METHODS ====================================

--- a/src/test/java/com/jfeatures/msg/codegen/util/JavaPackageNameBuilderTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/JavaPackageNameBuilderTest.java
@@ -50,9 +50,10 @@ class JavaPackageNameBuilderTest {
         String result = JavaPackageNameBuilder.buildJavaPackageName(domain, "dto");
 
         // Then
-        assertThat(result).startsWith("com.jfeatures.msg.");
-        assertThat(result).contains(domain.toLowerCase()); // Domain names are converted to lowercase
-        assertThat(result).endsWith(".dto");
+        assertThat(result)
+            .startsWith("com.jfeatures.msg.")
+            .contains(domain.toLowerCase()) // Domain names are converted to lowercase
+            .endsWith(".dto");
     }
 
     @Test

--- a/src/test/java/com/jfeatures/msg/codegen/util/MethodBuildersTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/MethodBuildersTest.java
@@ -34,8 +34,9 @@ class MethodBuildersTest {
         assertThat(constructor.name).isEqualTo("<init>");
         assertThat(constructor.modifiers).containsExactlyInAnyOrder(Modifier.PUBLIC);
         assertThat(constructor.parameters).hasSize(1);
-        assertThat(constructor.parameters.get(0).type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
-        assertThat(constructor.parameters.get(0).name).isEqualTo("namedParameterJdbcTemplate");
+        ParameterSpec parameter = constructor.parameters.get(0);
+        assertThat(parameter.type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
+        assertThat(parameter.name).isEqualTo("namedParameterJdbcTemplate");
         assertThat(constructor.javadoc.toString()).contains("Constructor with dependency injection for JDBC template");
         assertThat(constructor.code.toString()).contains("this.namedParameterJdbcTemplate = namedParameterJdbcTemplate");
     }
@@ -70,13 +71,16 @@ class MethodBuildersTest {
         assertThat(constructor.name).isEqualTo("<init>");
         assertThat(constructor.modifiers).containsExactlyInAnyOrder(Modifier.PUBLIC);
         assertThat(constructor.parameters).hasSize(2);
-        assertThat(constructor.parameters.get(0).type).isEqualTo(TypeName.get(DataSource.class));
-        assertThat(constructor.parameters.get(0).name).isEqualTo("dataSource");
-        assertThat(constructor.parameters.get(1).type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
-        assertThat(constructor.parameters.get(1).name).isEqualTo("jdbcTemplate");
+        ParameterSpec dataSourceParam = constructor.parameters.get(0);
+        assertThat(dataSourceParam.type).isEqualTo(TypeName.get(DataSource.class));
+        assertThat(dataSourceParam.name).isEqualTo("dataSource");
+        ParameterSpec jdbcTemplateParam = constructor.parameters.get(1);
+        assertThat(jdbcTemplateParam.type).isEqualTo(TypeName.get(NamedParameterJdbcTemplate.class));
+        assertThat(jdbcTemplateParam.name).isEqualTo("jdbcTemplate");
         assertThat(constructor.javadoc.toString()).contains("Constructor with dependency injection");
-        assertThat(constructor.code.toString()).contains("this.dataSource = dataSource");
-        assertThat(constructor.code.toString()).contains("this.jdbcTemplate = jdbcTemplate");
+        assertThat(constructor.code.toString())
+            .contains("this.dataSource = dataSource")
+            .contains("this.jdbcTemplate = jdbcTemplate");
     }
 
     @Test
@@ -114,8 +118,9 @@ class MethodBuildersTest {
         assertThat(constructor.name).isEqualTo("<init>");
         assertThat(constructor.modifiers).containsExactlyInAnyOrder(Modifier.PUBLIC);
         assertThat(constructor.parameters).hasSize(1);
-        assertThat(constructor.parameters.get(0).type).isEqualTo(dependencyType);
-        assertThat(constructor.parameters.get(0).name).isEqualTo(fieldName);
+        ParameterSpec parameter = constructor.parameters.get(0);
+        assertThat(parameter.type).isEqualTo(dependencyType);
+        assertThat(parameter.name).isEqualTo(fieldName);
         assertThat(constructor.javadoc.toString()).contains("Constructor with dependency injection");
         assertThat(constructor.code.toString()).contains("this.customerDAO = customerDAO");
     }
@@ -483,8 +488,10 @@ class MethodBuildersTest {
         Exception exception = assertThrows(Exception.class, constructor::newInstance);
         
         // The actual exception will be InvocationTargetException wrapping UnsupportedOperationException
-        assertThat(exception.getCause()).isInstanceOf(UnsupportedOperationException.class);
-        assertThat(exception.getCause().getMessage()).contains("This is a utility class and cannot be instantiated");
+        Throwable cause = exception.getCause();
+        assertThat(cause)
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("This is a utility class and cannot be instantiated");
     }
 
     // ============================= EDGE CASE TESTS ===================================
@@ -495,7 +502,8 @@ class MethodBuildersTest {
         MethodSpec constructor = MethodBuilders.jdbcTemplateConstructor("jdbcTemplate$WithSpecialChars");
         
         // Then
-        assertThat(constructor.parameters.get(0).name).isEqualTo("jdbcTemplate$WithSpecialChars");
+        ParameterSpec parameter = constructor.parameters.get(0);
+        assertThat(parameter.name).isEqualTo("jdbcTemplate$WithSpecialChars");
     }
 
     @Test
@@ -553,7 +561,8 @@ class MethodBuildersTest {
         
         // Then
         assertThat(method.returnType).isEqualTo(complexReturnType);
-        assertThat(method.parameters.get(0).type).isEqualTo(complexRequestType);
-        assertThat(method.parameters.get(0).name).isEqualTo("createRequest");
+        ParameterSpec parameter = method.parameters.get(0);
+        assertThat(parameter.type).isEqualTo(complexRequestType);
+        assertThat(parameter.name).isEqualTo("createRequest");
     }
 }

--- a/src/test/java/com/jfeatures/msg/codegen/util/NamingConventionsTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/NamingConventionsTest.java
@@ -355,7 +355,9 @@ class NamingConventionsTest {
         Exception exception = assertThrows(Exception.class, constructor::newInstance);
         
         // The actual exception will be InvocationTargetException wrapping UnsupportedOperationException
-        assertThat(exception.getCause()).isInstanceOf(UnsupportedOperationException.class);
-        assertThat(exception.getCause().getMessage()).contains("This is a utility class and cannot be instantiated");
+        Throwable cause = exception.getCause();
+        assertThat(cause)
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("This is a utility class and cannot be instantiated");
     }
 }

--- a/src/test/java/com/jfeatures/msg/codegen/util/ParameterBuildersTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/ParameterBuildersTest.java
@@ -286,16 +286,19 @@ class ParameterBuildersTest {
         
         // Then
         assertThat(parameters).hasSize(3);
-        
-        assertThat(parameters.get(0).name).isEqualTo("customerId");
-        assertThat(parameters.get(0).type).isEqualTo(ClassName.get(Long.class));
-        assertThat(parameters.get(0).annotations).hasSize(1);
-        
-        assertThat(parameters.get(1).name).isEqualTo("customerName");
-        assertThat(parameters.get(1).type).isEqualTo(ClassName.get(String.class));
-        
-        assertThat(parameters.get(2).name).isEqualTo("isActive");
-        assertThat(parameters.get(2).type).isEqualTo(ClassName.get(Boolean.class));
+
+        ParameterSpec firstParameter = parameters.get(0);
+        assertThat(firstParameter.name).isEqualTo("customerId");
+        assertThat(firstParameter.type).isEqualTo(ClassName.get(Long.class));
+        assertThat(firstParameter.annotations).hasSize(1);
+
+        ParameterSpec secondParameter = parameters.get(1);
+        assertThat(secondParameter.name).isEqualTo("customerName");
+        assertThat(secondParameter.type).isEqualTo(ClassName.get(String.class));
+
+        ParameterSpec thirdParameter = parameters.get(2);
+        assertThat(thirdParameter.name).isEqualTo("isActive");
+        assertThat(thirdParameter.type).isEqualTo(ClassName.get(Boolean.class));
     }
 
     @Test
@@ -346,13 +349,15 @@ class ParameterBuildersTest {
         
         // Then
         assertThat(parameters).hasSize(2);
-        
-        assertThat(parameters.get(0).name).isEqualTo("customerId");
-        assertThat(parameters.get(0).type.toString()).contains("Long");
-        assertThat(parameters.get(0).annotations).hasSize(1);
-        
-        assertThat(parameters.get(1).name).isEqualTo("customerName");
-        assertThat(parameters.get(1).type.toString()).contains("String");
+
+        ParameterSpec firstParameter = parameters.get(0);
+        assertThat(firstParameter.name).isEqualTo("customerId");
+        assertThat(firstParameter.type.toString()).contains("Long");
+        assertThat(firstParameter.annotations).hasSize(1);
+
+        ParameterSpec secondParameter = parameters.get(1);
+        assertThat(secondParameter.name).isEqualTo("customerName");
+        assertThat(secondParameter.type.toString()).contains("String");
     }
 
     @Test
@@ -397,15 +402,18 @@ class ParameterBuildersTest {
         
         // Then
         assertThat(parameters).hasSize(3);
-        
-        assertThat(parameters.get(0).name).isEqualTo("page");
-        assertThat(parameters.get(0).type).isEqualTo(ClassName.get(Integer.class));
-        
-        assertThat(parameters.get(1).name).isEqualTo("size");
-        assertThat(parameters.get(1).type).isEqualTo(ClassName.get(Integer.class));
-        
-        assertThat(parameters.get(2).name).isEqualTo("sort");
-        assertThat(parameters.get(2).type).isEqualTo(ClassName.get(String.class));
+
+        ParameterSpec pageParam = parameters.get(0);
+        assertThat(pageParam.name).isEqualTo("page");
+        assertThat(pageParam.type).isEqualTo(ClassName.get(Integer.class));
+
+        ParameterSpec sizeParam = parameters.get(1);
+        assertThat(sizeParam.name).isEqualTo("size");
+        assertThat(sizeParam.type).isEqualTo(ClassName.get(Integer.class));
+
+        ParameterSpec sortParam = parameters.get(2);
+        assertThat(sortParam.name).isEqualTo("sort");
+        assertThat(sortParam.type).isEqualTo(ClassName.get(String.class));
     }
 
     @Test
@@ -445,18 +453,22 @@ class ParameterBuildersTest {
         
         // Then
         assertThat(parameters).hasSize(4);
-        
-        assertThat(parameters.get(0).name).isEqualTo("customerId");
-        assertThat(parameters.get(0).type.toString()).contains("Long");
-        
-        assertThat(parameters.get(1).name).isEqualTo("status");
-        assertThat(parameters.get(1).type.toString()).contains("String");
-        
-        assertThat(parameters.get(2).name).isEqualTo("category");
-        assertThat(parameters.get(2).type.toString()).contains("String");
-        
-        assertThat(parameters.get(3).name).isEqualTo("extraParam");
-        assertThat(parameters.get(3).type.toString()).contains("Integer");
+
+        ParameterSpec firstParameter = parameters.get(0);
+        assertThat(firstParameter.name).isEqualTo("customerId");
+        assertThat(firstParameter.type.toString()).contains("Long");
+
+        ParameterSpec secondParameter = parameters.get(1);
+        assertThat(secondParameter.name).isEqualTo("status");
+        assertThat(secondParameter.type.toString()).contains("String");
+
+        ParameterSpec thirdParameter = parameters.get(2);
+        assertThat(thirdParameter.name).isEqualTo("category");
+        assertThat(thirdParameter.type.toString()).contains("String");
+
+        ParameterSpec fourthParameter = parameters.get(3);
+        assertThat(fourthParameter.name).isEqualTo("extraParam");
+        assertThat(fourthParameter.type.toString()).contains("Integer");
     }
 
     @Test
@@ -474,13 +486,10 @@ class ParameterBuildersTest {
         List<ParameterSpec> parameters = ParameterBuilders.whereClauseParameters(whereColumns);
         
         // Then
-        assertThat(parameters).hasSize(5);
-        
-        assertThat(parameters.get(0).name).isEqualTo("id");
-        assertThat(parameters.get(1).name).isEqualTo("status");
-        assertThat(parameters.get(2).name).isEqualTo("category");
-        assertThat(parameters.get(3).name).isEqualTo("param4");
-        assertThat(parameters.get(4).name).isEqualTo("param5");
+        assertThat(parameters)
+            .hasSize(5)
+            .extracting(parameter -> parameter.name)
+            .containsExactly("id", "status", "category", "param4", "param5");
     }
 
     @Test
@@ -513,8 +522,10 @@ class ParameterBuildersTest {
         Exception exception = assertThrows(Exception.class, constructor::newInstance);
         
         // The actual exception will be InvocationTargetException wrapping UnsupportedOperationException
-        assertThat(exception.getCause()).isInstanceOf(UnsupportedOperationException.class);
-        assertThat(exception.getCause().getMessage()).contains("This is a utility class and cannot be instantiated");
+        Throwable cause = exception.getCause();
+        assertThat(cause)
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("This is a utility class and cannot be instantiated");
     }
 
     // ============================= EDGE CASE TESTS ===================================
@@ -585,8 +596,9 @@ class ParameterBuildersTest {
         
         // Then - Should be boxed to Integer, not primitive int
         assertThat(parameters).hasSize(1);
-        assertThat(parameters.get(0).type).isEqualTo(ClassName.get(Integer.class));
-        assertThat(parameters.get(0).name).isEqualTo("countValue");
+        ParameterSpec parameter = parameters.get(0);
+        assertThat(parameter.type).isEqualTo(ClassName.get(Integer.class));
+        assertThat(parameter.name).isEqualTo("countValue");
     }
 
     // ============================= HELPER METHODS ====================================


### PR DESCRIPTION
## Summary
- chain repeated AssertJ contains checks in generator tests to remove consecutive assertThat calls flagged by S5853
- refactor builder-related tests to reuse captured parameters and consolidate assertions, avoiding duplicate assertThat invocations
- centralize utility-class instantiation assertions onto shared Throwable variables so causes are verified without redundant assertThat calls

## Testing
- `mvn -DskipITs test` *(fails: cannot download org.springframework.boot:spring-boot-maven-plugin:3.3.4 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cc960808832a95c099cf3fe7f0da