### PR TITLE
refactor: deduplicate repeated string literals

### DIFF
--- a/src/main/java/com/jfeatures/msg/codegen/GenerateController.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateController.java
@@ -1,5 +1,7 @@
 package com.jfeatures.msg.codegen;
 
+import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
+import com.jfeatures.msg.codegen.constants.ProjectConstants;
 import com.jfeatures.msg.codegen.domain.DBColumn;
 import com.jfeatures.msg.codegen.util.JavaPackageNameBuilder;
 import com.jfeatures.msg.codegen.util.JavaPoetTypeNameBuilder;
@@ -64,8 +66,11 @@ public class GenerateController {
         predicateHavingLiterals.forEach(literal ->
                 parameterSpecs.add(ParameterSpec.builder(ClassName.bestGuess(literal.javaType()).box(),
                                 CaseUtils.toCamelCase(literal.columnName(), false))
-                                .addAnnotation(AnnotationSpec.builder(RequestParam.class).addMember("value", "$S",
-                                        CaseUtils.toCamelCase(literal.columnName(), false)).build())
+                                .addAnnotation(AnnotationSpec.builder(RequestParam.class)
+                                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                                CaseUtils.toCamelCase(literal.columnName(), false))
+                                        .build())
                         .build()));
 
         CodeBlock serviceCodeBlock = CodeBlock.builder()
@@ -74,11 +79,15 @@ public class GenerateController {
 
         MethodSpec methodSpec = MethodSpec.methodBuilder("getDataFor" + businessPurposeOfSQL)
                 .addAnnotation(AnnotationSpec.builder(GetMapping.class)
-                        .addMember("value", "$S", "/"+ businessPurposeOfSQL)
-                        .addMember("produces", "$S", "application/json")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, "/" + businessPurposeOfSQL)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PRODUCES,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, ProjectConstants.APPLICATION_JSON)
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Operation.class)
-                        .addMember("summary", "$S", "Get API to fetch data for " + businessPurposeOfSQL)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_SUMMARY,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "Get API to fetch data for " + businessPurposeOfSQL)
                         .build())
                 .addParameters(parameterSpecs)
                 .addModifiers(Modifier.PUBLIC)
@@ -94,11 +103,13 @@ public class GenerateController {
                 .addMethod(constructorSpec)
                 .addAnnotation(RestController.class)
                 .addAnnotation(AnnotationSpec.builder(RequestMapping.class)
-                        .addMember("path", "$S", "/api")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PATH,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, "/api")
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Tag.class)
-                        .addMember("name", "$S", businessPurposeOfSQL)
-                        .addMember("description", "$S", businessPurposeOfSQL)
+                        .addMember("name", CodeGenerationConstants.STRING_PLACEHOLDER, businessPurposeOfSQL)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, businessPurposeOfSQL)
                         .build())
                 .build();
 

--- a/src/main/java/com/jfeatures/msg/codegen/GenerateDeleteController.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateDeleteController.java
@@ -1,5 +1,7 @@
 package com.jfeatures.msg.codegen;
 
+import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
+import com.jfeatures.msg.codegen.constants.ProjectConstants;
 import com.jfeatures.msg.codegen.dbmetadata.ColumnMetadata;
 import com.jfeatures.msg.codegen.dbmetadata.DeleteMetadata;
 import com.jfeatures.msg.codegen.util.JavaPackageNameBuilder;
@@ -77,11 +79,13 @@ public class GenerateDeleteController {
         for (ColumnMetadata column : deleteMetadata.whereColumns()) {
             Class<?> paramType = SQLServerDataTypeEnum.getClassForType(column.getColumnTypeName());
             String paramName = CaseUtils.toCamelCase(column.getColumnName(), false);
-            
+
             ParameterSpec paramSpec = ParameterSpec.builder(paramType, paramName)
                     .addAnnotation(AnnotationSpec.builder(RequestParam.class)
-                            .addMember("value", "$S", paramName.toLowerCase())
-                            .addMember("required", "$L", true)
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                    CodeGenerationConstants.STRING_PLACEHOLDER, paramName.toLowerCase())
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_REQUIRED,
+                                    CodeGenerationConstants.LITERAL_PLACEHOLDER, true)
                             .build())
                     .build();
             
@@ -93,12 +97,18 @@ public class GenerateDeleteController {
         MethodSpec.Builder deleteMethodBuilder = MethodSpec.methodBuilder("delete" + businessPurposeOfSQL)
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(DeleteMapping.class)
-                        .addMember("value", "$S", "/" + businessPurposeOfSQL.toLowerCase())
-                        .addMember("produces", "$S", "application/json")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, "/" + businessPurposeOfSQL.toLowerCase())
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PRODUCES,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, ProjectConstants.APPLICATION_JSON)
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Operation.class)
-                        .addMember("summary", "$S", "Delete " + businessPurposeOfSQL.toLowerCase() + " entity")
-                        .addMember("description", "$S", "DELETE API to remove a " + businessPurposeOfSQL.toLowerCase() + " record")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_SUMMARY,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "Delete " + businessPurposeOfSQL.toLowerCase() + " entity")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "DELETE API to remove a " + businessPurposeOfSQL.toLowerCase() + " record")
                         .build())
                 .returns(ClassName.get("org.springframework.http", "ResponseEntity").withoutAnnotations());
         
@@ -131,11 +141,14 @@ public class GenerateDeleteController {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(RestController.class).build())
                 .addAnnotation(AnnotationSpec.builder(RequestMapping.class)
-                        .addMember("path", "$S", "/api")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PATH,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, "/api")
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Tag.class)
-                        .addMember("name", "$S", businessPurposeOfSQL)
-                        .addMember("description", "$S", businessPurposeOfSQL + " DELETE operations")
+                        .addMember("name", CodeGenerationConstants.STRING_PLACEHOLDER, businessPurposeOfSQL)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                businessPurposeOfSQL + " DELETE operations")
                         .build())
                 .addField(daoFieldSpec)
                 .addMethod(constructorSpec)

--- a/src/main/java/com/jfeatures/msg/codegen/GenerateInsertController.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateInsertController.java
@@ -1,5 +1,7 @@
 package com.jfeatures.msg.codegen;
 
+import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
+import com.jfeatures.msg.codegen.constants.ProjectConstants;
 import com.jfeatures.msg.codegen.dbmetadata.InsertMetadata;
 import com.jfeatures.msg.codegen.util.CommonJavaPoetBuilders;
 import com.jfeatures.msg.codegen.util.JavaPackageNameBuilder;
@@ -62,13 +64,20 @@ public class GenerateInsertController {
         MethodSpec insertMethodSpec = MethodSpec.methodBuilder("create" + businessPurposeOfSQL)
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(PostMapping.class)
-                        .addMember("value", "$S", "/" + businessPurposeOfSQL.toLowerCase())
-                        .addMember("consumes", "$S", "application/json")
-                        .addMember("produces", "$S", "application/json")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, "/" + businessPurposeOfSQL.toLowerCase())
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_CONSUMES,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, ProjectConstants.APPLICATION_JSON)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PRODUCES,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, ProjectConstants.APPLICATION_JSON)
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Operation.class)
-                        .addMember("summary", "$S", "Create new " + businessPurposeOfSQL.toLowerCase() + " entity")
-                        .addMember("description", "$S", "POST API to create a new " + businessPurposeOfSQL.toLowerCase() + " record")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_SUMMARY,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "Create new " + businessPurposeOfSQL.toLowerCase() + " entity")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "POST API to create a new " + businessPurposeOfSQL.toLowerCase() + " record")
                         .build())
                 .addParameter(ParameterSpec.builder(insertDtoTypeName, "insertRequest")
                         .addAnnotation(AnnotationSpec.builder(Valid.class).build())
@@ -91,8 +100,10 @@ public class GenerateInsertController {
         TypeSpec.Builder controllerBuilder = CommonJavaPoetBuilders.basicControllerClass(businessPurposeOfSQL + "Insert", "/api");
         TypeSpec controller = controllerBuilder
                 .addAnnotation(AnnotationSpec.builder(Tag.class)
-                        .addMember("name", "$S", businessPurposeOfSQL)
-                        .addMember("description", "$S", businessPurposeOfSQL + " INSERT operations")
+                        .addMember("name", CodeGenerationConstants.STRING_PLACEHOLDER, businessPurposeOfSQL)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                businessPurposeOfSQL + " INSERT operations")
                         .build())
                 .addField(FieldSpec.builder(insertDaoTypeName, daoInstanceFieldName)
                         .addModifiers(Modifier.PRIVATE, Modifier.FINAL)

--- a/src/main/java/com/jfeatures/msg/codegen/GenerateUpdateController.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateUpdateController.java
@@ -1,5 +1,7 @@
 package com.jfeatures.msg.codegen;
 
+import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
+import com.jfeatures.msg.codegen.constants.ProjectConstants;
 import com.jfeatures.msg.codegen.dbmetadata.ColumnMetadata;
 import com.jfeatures.msg.codegen.dbmetadata.UpdateMetadata;
 import com.jfeatures.msg.codegen.util.JavaPackageNameBuilder;
@@ -39,6 +41,8 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Slf4j
 public class GenerateUpdateController {
+
+    private static final String ID_PARAMETER = "id";
 
     private GenerateUpdateController() {
         throw new UnsupportedOperationException("Utility class");
@@ -80,11 +84,14 @@ public class GenerateUpdateController {
                 .addMethod(putMethod)
                 .addAnnotation(RestController.class)
                 .addAnnotation(AnnotationSpec.builder(RequestMapping.class)
-                        .addMember("path", "$S", "/api")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PATH,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, "/api")
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Tag.class)
-                        .addMember("name", "$S", businessPurposeOfSQL + " Update API")
-                        .addMember("description", "$S", "REST API for updating " + businessPurposeOfSQL.toLowerCase() + " records")
+                        .addMember("name", CodeGenerationConstants.STRING_PLACEHOLDER, businessPurposeOfSQL + " Update API")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "REST API for updating " + businessPurposeOfSQL.toLowerCase() + " records")
                         .build())
                 .build();
         
@@ -110,8 +117,11 @@ public class GenerateUpdateController {
                 .addAnnotation(Valid.class)
                 .addAnnotation(RequestBody.class)
                 .addAnnotation(AnnotationSpec.builder(Parameter.class)
-                        .addMember("description", "$S", "Updated " + businessPurposeOfSQL.toLowerCase() + " data")
-                        .addMember("required", "true")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "Updated " + businessPurposeOfSQL.toLowerCase() + " data")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_REQUIRED,
+                                CodeGenerationConstants.LITERAL_PLACEHOLDER, true)
                         .build())
                 .build());
         methodCallParams.add("updateDto");
@@ -122,16 +132,19 @@ public class GenerateUpdateController {
             ColumnMetadata firstWhereColumn = updateMetadata.whereColumns().get(0);
             Class<?> idType = SQLServerDataTypeEnum.getClassForType(firstWhereColumn.getColumnTypeName());
             
-            parameterSpecs.add(ParameterSpec.builder(idType, "id")
+            parameterSpecs.add(ParameterSpec.builder(idType, ID_PARAMETER)
                     .addAnnotation(AnnotationSpec.builder(PathVariable.class)
-                            .addMember("value", "$S", "id")
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                    CodeGenerationConstants.STRING_PLACEHOLDER, ID_PARAMETER)
                             .build())
                     .addAnnotation(AnnotationSpec.builder(Parameter.class)
-                            .addMember("description", "$S", "Unique identifier")
-                            .addMember("required", "true")
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                    CodeGenerationConstants.STRING_PLACEHOLDER, "Unique identifier")
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_REQUIRED,
+                                    CodeGenerationConstants.LITERAL_PLACEHOLDER, true)
                             .build())
                     .build());
-            methodCallParams.add("id");
+            methodCallParams.add(ID_PARAMETER);
             hasPathVariable = true;
         }
         
@@ -143,11 +156,14 @@ public class GenerateUpdateController {
             
             parameterSpecs.add(ParameterSpec.builder(paramType, paramName)
                     .addAnnotation(AnnotationSpec.builder(RequestParam.class)
-                            .addMember("value", "$S", paramName)
-                            .addMember("required", "true")
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                    CodeGenerationConstants.STRING_PLACEHOLDER, paramName)
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_REQUIRED,
+                                    CodeGenerationConstants.LITERAL_PLACEHOLDER, true)
                             .build())
                     .addAnnotation(AnnotationSpec.builder(Parameter.class)
-                            .addMember("description", "$S", "Filter parameter: " + paramName)
+                            .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                    CodeGenerationConstants.STRING_PLACEHOLDER, "Filter parameter: " + paramName)
                             .build())
                     .build());
             methodCallParams.add(paramName);
@@ -177,12 +193,18 @@ public class GenerateUpdateController {
                 .addParameters(parameterSpecs)
                 .returns(ParameterizedTypeName.get(ClassName.get(ResponseEntity.class), ClassName.get(Void.class)))
                 .addAnnotation(AnnotationSpec.builder(PutMapping.class)
-                        .addMember("value", "$S", mappingUrl)
-                        .addMember("consumes", "$S", "application/json")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, mappingUrl)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_CONSUMES,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, ProjectConstants.APPLICATION_JSON)
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Operation.class)
-                        .addMember("summary", "$S", "Update " + businessPurposeOfSQL.toLowerCase() + " record")
-                        .addMember("description", "$S", "Updates an existing " + businessPurposeOfSQL.toLowerCase() + " record with the provided data")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_SUMMARY,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "Update " + businessPurposeOfSQL.toLowerCase() + " record")
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "Updates an existing " + businessPurposeOfSQL.toLowerCase() + " record with the provided data")
                         .build())
                 .addAnnotation(AnnotationSpec.builder(ApiResponses.class)
                         .addMember("value", "{\n" +
@@ -213,7 +235,7 @@ public class GenerateUpdateController {
         
         // Generate names based on common patterns
         return switch (index) {
-            case 0 -> "id";
+            case 0 -> ID_PARAMETER;
             case 1 -> "status";
             case 2 -> "category";
             default -> "param" + (index + 1);

--- a/src/main/java/com/jfeatures/msg/codegen/SQLServerDataTypeEnum.java
+++ b/src/main/java/com/jfeatures/msg/codegen/SQLServerDataTypeEnum.java
@@ -18,35 +18,35 @@ import java.util.stream.Collectors;
 public enum SQLServerDataTypeEnum {
 
     BIGINT("BIGINT", Long.class, "Long" ),
-    BINARY("BINARY", byte[].class, "Byte[]" ),
+    BINARY("BINARY", byte[].class, BYTE_ARRAY_SIMPLE_NAME ),
     BIT("BIT", Boolean.class, "Boolean"),
-    CHAR("CHAR", String.class, "String" ),
+    CHAR("CHAR", String.class, JAVA_STRING_SIMPLE_NAME ),
     DATE("DATE", java.sql.Date.class, "Date"),
-    DATETIME("DATETIME", java.sql.Timestamp.class, "Timestamp" ),
-    DATETIME2("DATETIME2", java.sql.Timestamp.class, "Timestamp" ),
-    DECIMAL("DECIMAL", java.math.BigDecimal.class, "BigDecimal" ),
-    INT("INT", Integer.class, "Int" ),
+    DATETIME("DATETIME", java.sql.Timestamp.class, JAVA_TIMESTAMP_SIMPLE_NAME ),
+    DATETIME2("DATETIME2", java.sql.Timestamp.class, JAVA_TIMESTAMP_SIMPLE_NAME ),
+    DECIMAL("DECIMAL", java.math.BigDecimal.class, JAVA_BIG_DECIMAL_SIMPLE_NAME ),
+    INT("INT", Integer.class, JAVA_INT_SIMPLE_NAME ),
     FLOAT("FLOAT", Double.class, "Double" ),
-    IMAGE("IMAGE", byte[].class, "Byte[]" ),
-    MONEY("MONEY", java.math.BigDecimal.class, "BigDecimal" ),
-    NCHAR("NCHAR", String.class, "String" ),
-    NTEXT("NTEXT", String.class, "String" ),
-    NUMERIC("NUMERIC", java.math.BigDecimal.class, "BigDecimal" ),
-    NVARCHAR("NVARCHAR", String.class, "String"),
+    IMAGE("IMAGE", byte[].class, BYTE_ARRAY_SIMPLE_NAME ),
+    MONEY("MONEY", java.math.BigDecimal.class, JAVA_BIG_DECIMAL_SIMPLE_NAME ),
+    NCHAR("NCHAR", String.class, JAVA_STRING_SIMPLE_NAME ),
+    NTEXT("NTEXT", String.class, JAVA_STRING_SIMPLE_NAME ),
+    NUMERIC("NUMERIC", java.math.BigDecimal.class, JAVA_BIG_DECIMAL_SIMPLE_NAME ),
+    NVARCHAR("NVARCHAR", String.class, JAVA_STRING_SIMPLE_NAME),
     REAL("REAL", Float.class, "Float" ),
-    SMALLDATETIME("SMALLDATETIME", java.sql.Timestamp.class, "Timestamp" ),
-    SMALLINT("SMALLINT", Integer.class, "Int" ),
-    SMALLMONEY("SMALLMONEY", java.math.BigDecimal.class, "BigDecimal" ),
-    TEXT("TEXT", String.class, "String" ),
+    SMALLDATETIME("SMALLDATETIME", java.sql.Timestamp.class, JAVA_TIMESTAMP_SIMPLE_NAME ),
+    SMALLINT("SMALLINT", Integer.class, JAVA_INT_SIMPLE_NAME ),
+    SMALLMONEY("SMALLMONEY", java.math.BigDecimal.class, JAVA_BIG_DECIMAL_SIMPLE_NAME ),
+    TEXT("TEXT", String.class, JAVA_STRING_SIMPLE_NAME ),
     TIME("TIME", java.sql.Time.class, "Time" ),
-    TIMESTAMP("TIMESTAMP", java.sql.Timestamp.class, "Timestamp" ),
-    TINYINT("TINYINT", Integer.class, "Int" ),
-    VARCHAR("VARCHAR", String.class, "String" ),
+    TIMESTAMP("TIMESTAMP", java.sql.Timestamp.class, JAVA_TIMESTAMP_SIMPLE_NAME ),
+    TINYINT("TINYINT", Integer.class, JAVA_INT_SIMPLE_NAME ),
+    VARCHAR("VARCHAR", String.class, JAVA_STRING_SIMPLE_NAME ),
     
     // Additional SQL Server types for completeness
-    UNIQUEIDENTIFIER("UNIQUEIDENTIFIER", String.class, "String"),
-    VARBINARY("VARBINARY", byte[].class, "Byte[]"),
-    XML("XML", String.class, "String");
+    UNIQUEIDENTIFIER("UNIQUEIDENTIFIER", String.class, JAVA_STRING_SIMPLE_NAME),
+    VARBINARY("VARBINARY", byte[].class, BYTE_ARRAY_SIMPLE_NAME),
+    XML("XML", String.class, JAVA_STRING_SIMPLE_NAME);
 
     private final String dbDataType;
     private final Class<?> javaClassType;
@@ -99,7 +99,7 @@ public enum SQLServerDataTypeEnum {
      * Retrieves the JDBC type string for a given SQL Server data type.
      * 
      * @param dbDataType The SQL Server data type (case-insensitive)
-     * @return The corresponding JDBC type string, or "VARCHAR" if type not found
+     * @return The corresponding JDBC type string, or the default JDBC type if none is found
      * @throws IllegalArgumentException if the dbDataType is null or empty
      */
     public static String getJdbcTypeForDBType(String dbDataType) {
@@ -108,6 +108,13 @@ public enum SQLServerDataTypeEnum {
         }
         
         SQLServerDataTypeEnum enumValue = DB_TYPE_LOOKUP.get(dbDataType.toUpperCase().trim());
-        return enumValue != null ? enumValue.jdbcType : "VARCHAR";
+        return enumValue != null ? enumValue.jdbcType : JDBC_DEFAULT_TYPE;
     }
+
+    private static final String JAVA_STRING_SIMPLE_NAME = "String";
+    private static final String JAVA_TIMESTAMP_SIMPLE_NAME = "Timestamp";
+    private static final String JAVA_BIG_DECIMAL_SIMPLE_NAME = "BigDecimal";
+    private static final String JAVA_INT_SIMPLE_NAME = "Int";
+    private static final String BYTE_ARRAY_SIMPLE_NAME = "Byte[]";
+    private static final String JDBC_DEFAULT_TYPE = "VARCHAR";
 }

--- a/src/main/java/com/jfeatures/msg/codegen/constants/CodeGenerationConstants.java
+++ b/src/main/java/com/jfeatures/msg/codegen/constants/CodeGenerationConstants.java
@@ -18,8 +18,19 @@ public final class CodeGenerationConstants {
     public static final String BUILDER_VARIABLE_NAME = "Builder";
     public static final String DTO_VARIABLE_NAME = "dto";
     public static final String RESULT_LIST_NAME = "result";
-    
+
     // Method prefixes
     public static final String DAO_METHOD_PREFIX = "get";
     public static final String SETTER_METHOD_PREFIX = "set";
+
+    // Commonly reused JavaPoet placeholders and annotation members
+    public static final String STRING_PLACEHOLDER = "$S";
+    public static final String LITERAL_PLACEHOLDER = "$L";
+    public static final String ANNOTATION_MEMBER_VALUE = "value";
+    public static final String ANNOTATION_MEMBER_PATH = "path";
+    public static final String ANNOTATION_MEMBER_DESCRIPTION = "description";
+    public static final String ANNOTATION_MEMBER_REQUIRED = "required";
+    public static final String ANNOTATION_MEMBER_PRODUCES = "produces";
+    public static final String ANNOTATION_MEMBER_CONSUMES = "consumes";
+    public static final String ANNOTATION_MEMBER_SUMMARY = "summary";
 }

--- a/src/main/java/com/jfeatures/msg/codegen/sql/SqlFileResolver.java
+++ b/src/main/java/com/jfeatures/msg/codegen/sql/SqlFileResolver.java
@@ -64,11 +64,13 @@ public class SqlFileResolver {
             log.info("Using SELECT SQL file: {}", ProjectConstants.DEFAULT_SELECT_SQL_FILE);
             return sql;
         } catch (RuntimeException e) {
-            throw new IllegalArgumentException("No default SQL files found. Please provide a specific SQL file or ensure at least one of the following files exists: " +
-                    ProjectConstants.DEFAULT_UPDATE_SQL_FILE + ", " + 
-                    ProjectConstants.DEFAULT_INSERT_SQL_FILE + ", " + 
-                    ProjectConstants.DEFAULT_DELETE_SQL_FILE + ", " + 
+            String availableFiles = String.join(", ",
+                    ProjectConstants.DEFAULT_UPDATE_SQL_FILE,
+                    ProjectConstants.DEFAULT_INSERT_SQL_FILE,
+                    ProjectConstants.DEFAULT_DELETE_SQL_FILE,
                     ProjectConstants.DEFAULT_SELECT_SQL_FILE);
+            throw new IllegalArgumentException("No default SQL files found. Please provide a specific SQL file or ensure at least one of the following files exists: "
+                    + availableFiles);
         }
     }
     

--- a/src/main/java/com/jfeatures/msg/codegen/util/ClassBuilders.java
+++ b/src/main/java/com/jfeatures/msg/codegen/util/ClassBuilders.java
@@ -1,5 +1,6 @@
 package com.jfeatures.msg.codegen.util;
 
+import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
 import com.jfeatures.msg.codegen.constants.ProjectConstants;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.TypeSpec;
@@ -72,11 +73,14 @@ public final class ClassBuilders {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(RestController.class)
                 .addAnnotation(AnnotationSpec.builder(RequestMapping.class)
-                        .addMember("path", "$S", apiPath)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PATH,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, apiPath)
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Tag.class)
-                        .addMember("name", "$S", businessName)
-                        .addMember("description", "$S", "REST API for " + businessName.toLowerCase() + " operations")
+                        .addMember("name", CodeGenerationConstants.STRING_PLACEHOLDER, businessName)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                "REST API for " + businessName.toLowerCase() + " operations")
                         .build())
                 .addJavadoc("REST Controller for $L operations.\\nProvides HTTP endpoints for data access.", businessName.toLowerCase());
     }
@@ -95,11 +99,14 @@ public final class ClassBuilders {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(RestController.class)
                 .addAnnotation(AnnotationSpec.builder(RequestMapping.class)
-                        .addMember("path", "$S", apiPath)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PATH,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, apiPath)
                         .build())
                 .addAnnotation(AnnotationSpec.builder(Tag.class)
-                        .addMember("name", "$S", businessName + " " + operation)
-                        .addMember("description", "$S", operation + " operations for " + businessName.toLowerCase())
+                        .addMember("name", CodeGenerationConstants.STRING_PLACEHOLDER, businessName + " " + operation)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_DESCRIPTION,
+                                CodeGenerationConstants.STRING_PLACEHOLDER,
+                                operation + " operations for " + businessName.toLowerCase())
                         .build())
                 .addJavadoc("REST Controller for $L $L operations.\\nFollows single responsibility principle - $L operations only.", 
                            businessName.toLowerCase(), operation.toLowerCase(), operation.toLowerCase());
@@ -118,7 +125,8 @@ public final class ClassBuilders {
         return TypeSpec.classBuilder(className)
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(Builder.class)
-                        .addMember("builderClassName", "$S", "Builder")
+                        .addMember("builderClassName", CodeGenerationConstants.STRING_PLACEHOLDER,
+                                CodeGenerationConstants.BUILDER_VARIABLE_NAME)
                         .build())
                 .addAnnotation(Value.class)
                 .addAnnotation(Jacksonized.class)
@@ -137,7 +145,8 @@ public final class ClassBuilders {
         return TypeSpec.classBuilder(className)
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(Builder.class)
-                        .addMember("builderClassName", "$S", "Builder")
+                        .addMember("builderClassName", CodeGenerationConstants.STRING_PLACEHOLDER,
+                                CodeGenerationConstants.BUILDER_VARIABLE_NAME)
                         .build())
                 .addAnnotation(Value.class)
                 .addAnnotation(Jacksonized.class)

--- a/src/main/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuilders.java
+++ b/src/main/java/com/jfeatures/msg/codegen/util/CommonJavaPoetBuilders.java
@@ -1,5 +1,6 @@
 package com.jfeatures.msg.codegen.util;
 
+import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
 import com.squareup.javapoet.*;
 import jakarta.validation.Valid;
 import javax.lang.model.element.Modifier;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
  * Provides standardized field, method, and class builders for consistent code generation.
  */
 public final class CommonJavaPoetBuilders {
+
+    private static final String THIS_ASSIGNMENT_STATEMENT = "this.$N = $N";
 
     private CommonJavaPoetBuilders() {
         // utility class
@@ -34,9 +37,9 @@ public final class CommonJavaPoetBuilders {
      */
     public static FieldSpec sqlField(String sql, String businessName) {
         String fieldName = businessName.toLowerCase() + "Sql";
-        return FieldSpec.builder(String.class, fieldName, 
+        return FieldSpec.builder(String.class, fieldName,
                 Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                .initializer("$S", sql)
+                .initializer(CodeGenerationConstants.STRING_PLACEHOLDER, sql)
                 .build();
     }
     
@@ -70,7 +73,7 @@ public final class CommonJavaPoetBuilders {
         return MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(NamedParameterJdbcTemplate.class, fieldName)
-                .addStatement("this.$N = $N", fieldName, fieldName)
+                .addStatement(THIS_ASSIGNMENT_STATEMENT, fieldName, fieldName)
                 .build();
     }
     
@@ -82,8 +85,8 @@ public final class CommonJavaPoetBuilders {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(DataSource.class, dataSourceField)
                 .addParameter(NamedParameterJdbcTemplate.class, jdbcTemplateField)
-                .addStatement("this.$N = $N", dataSourceField, dataSourceField)
-                .addStatement("this.$N = $N", jdbcTemplateField, jdbcTemplateField)
+                .addStatement(THIS_ASSIGNMENT_STATEMENT, dataSourceField, dataSourceField)
+                .addStatement(THIS_ASSIGNMENT_STATEMENT, jdbcTemplateField, jdbcTemplateField)
                 .build();
     }
     
@@ -112,7 +115,8 @@ public final class CommonJavaPoetBuilders {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(RestController.class)
                 .addAnnotation(AnnotationSpec.builder(RequestMapping.class)
-                        .addMember("path", "$S", basePath)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_PATH,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, basePath)
                         .build());
     }
     
@@ -193,7 +197,8 @@ public final class CommonJavaPoetBuilders {
     public static ParameterSpec requestParamWithName(TypeName type, String paramName, String requestParamName) {
         return ParameterSpec.builder(type, paramName)
                 .addAnnotation(AnnotationSpec.builder(RequestParam.class)
-                        .addMember("value", "$S", requestParamName)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, requestParamName)
                         .build())
                 .build();
     }

--- a/src/main/java/com/jfeatures/msg/codegen/util/FieldBuilders.java
+++ b/src/main/java/com/jfeatures/msg/codegen/util/FieldBuilders.java
@@ -13,7 +13,11 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
  * Follows Single Responsibility Principle - only field creation logic.
  */
 public final class FieldBuilders {
-    
+
+    private static final String FIELD_NAME_PARAM = "fieldName";
+    private static final String BUSINESS_NAME_PARAM = "businessName";
+    private static final String OPERATION_PARAM = "operation";
+
     private FieldBuilders() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
@@ -24,9 +28,9 @@ public final class FieldBuilders {
      * Creates a private final NamedParameterJdbcTemplate field.
      */
     public static FieldSpec jdbcTemplateField(String fieldName) {
-        validateNotEmpty(fieldName, "fieldName");
-        
-        return FieldSpec.builder(NamedParameterJdbcTemplate.class, fieldName, 
+        validateNotEmpty(fieldName, FIELD_NAME_PARAM);
+
+        return FieldSpec.builder(NamedParameterJdbcTemplate.class, fieldName,
                 Modifier.PRIVATE, Modifier.FINAL)
                 .build();
     }
@@ -35,9 +39,9 @@ public final class FieldBuilders {
      * Creates a private final DataSource field.
      */
     public static FieldSpec dataSourceField(String fieldName) {
-        validateNotEmpty(fieldName, "fieldName");
-        
-        return FieldSpec.builder(DataSource.class, fieldName, 
+        validateNotEmpty(fieldName, FIELD_NAME_PARAM);
+
+        return FieldSpec.builder(DataSource.class, fieldName,
                 Modifier.PRIVATE, Modifier.FINAL)
                 .build();
     }
@@ -49,7 +53,7 @@ public final class FieldBuilders {
      */
     public static FieldSpec sqlField(String sql, String fieldName) {
         validateNotEmpty(sql, "sql");
-        validateNotEmpty(fieldName, "fieldName");
+        validateNotEmpty(fieldName, FIELD_NAME_PARAM);
         
         return FieldSpec.builder(String.class, fieldName, 
                 Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
@@ -62,9 +66,9 @@ public final class FieldBuilders {
      */
     public static FieldSpec sqlFieldWithJavaDoc(String sql, String fieldName, String operation, String businessName) {
         validateNotEmpty(sql, "sql");
-        validateNotEmpty(fieldName, "fieldName");
-        validateNotEmpty(operation, "operation");
-        validateNotEmpty(businessName, "businessName");
+        validateNotEmpty(fieldName, FIELD_NAME_PARAM);
+        validateNotEmpty(operation, OPERATION_PARAM);
+        validateNotEmpty(businessName, BUSINESS_NAME_PARAM);
         
         return FieldSpec.builder(String.class, fieldName, 
                 Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
@@ -127,7 +131,7 @@ public final class FieldBuilders {
      */
     public static FieldSpec daoField(TypeName daoType, String businessName) {
         validateNotNull(daoType, "daoType");
-        validateNotEmpty(businessName, "businessName");
+        validateNotEmpty(businessName, BUSINESS_NAME_PARAM);
         
         String fieldName = NamingConventions.daoFieldName(businessName);
         

--- a/src/main/java/com/jfeatures/msg/codegen/util/NamingConventions.java
+++ b/src/main/java/com/jfeatures/msg/codegen/util/NamingConventions.java
@@ -1,6 +1,7 @@
 package com.jfeatures.msg.codegen.util;
 
 import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
+import com.jfeatures.msg.codegen.constants.ProjectConstants;
 import org.apache.commons.text.CaseUtils;
 
 /**
@@ -8,7 +9,12 @@ import org.apache.commons.text.CaseUtils;
  * Follows Clean Code principles: single responsibility for naming logic.
  */
 public final class NamingConventions {
-    
+
+    private static final String PACKAGE_SUFFIX_PARAM = "packageSuffix";
+    private static final String CLASS_SUFFIX_PARAM = "classSuffix";
+    private static final String FIELD_NAME_PARAM = "fieldName";
+    private static final String COLUMN_NAME_PARAM = "columnName";
+
     // Private constructor to prevent instantiation
     private NamingConventions() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
@@ -21,8 +27,8 @@ public final class NamingConventions {
      * Pattern: com.jfeatures.msg.{businessName}.{packageSuffix}
      */
     public static String buildPackageName(String businessName, String packageSuffix) {
-        validateNotEmpty(businessName, "businessName");
-        validateNotEmpty(packageSuffix, "packageSuffix");
+        validateNotEmpty(businessName, ProjectConstants.BUSINESS_NAME_PARAM);
+        validateNotEmpty(packageSuffix, PACKAGE_SUFFIX_PARAM);
         
         return "com.jfeatures.msg." + businessName.toLowerCase() + "." + packageSuffix;
     }
@@ -34,8 +40,8 @@ public final class NamingConventions {
      * Pattern: {BusinessName}{ClassSuffix}
      */
     public static String buildClassName(String businessName, String classSuffix) {
-        validateNotEmpty(businessName, "businessName");
-        validateNotEmpty(classSuffix, "classSuffix");
+        validateNotEmpty(businessName, ProjectConstants.BUSINESS_NAME_PARAM);
+        validateNotEmpty(classSuffix, CLASS_SUFFIX_PARAM);
         
         // Handle empty string cases
         if (businessName.isEmpty()) {
@@ -78,7 +84,7 @@ public final class NamingConventions {
      * Creates a field name for JDBC template following naming conventions.
      */
     public static String jdbcTemplateFieldName(String businessName) {
-        validateNotEmpty(businessName, "businessName");
+        validateNotEmpty(businessName, ProjectConstants.BUSINESS_NAME_PARAM);
         return CaseUtils.toCamelCase(businessName, false) + "NamedParameterJdbcTemplate";
     }
     
@@ -86,7 +92,7 @@ public final class NamingConventions {
      * Creates a DAO field name for controllers.
      */
     public static String daoFieldName(String businessName) {
-        validateNotEmpty(businessName, "businessName");
+        validateNotEmpty(businessName, ProjectConstants.BUSINESS_NAME_PARAM);
         return CaseUtils.toCamelCase(businessName, false) + "DAO";
     }
     
@@ -104,7 +110,7 @@ public final class NamingConventions {
      * Creates getter method name from field name.
      */
     public static String getterMethodName(String fieldName) {
-        validateNotEmpty(fieldName, "fieldName");
+        validateNotEmpty(fieldName, FIELD_NAME_PARAM);
         return "get" + CaseUtils.toCamelCase(fieldName, true, '_');
     }
     
@@ -112,7 +118,7 @@ public final class NamingConventions {
      * Creates setter method name from field name.
      */
     public static String setterMethodName(String fieldName) {
-        validateNotEmpty(fieldName, "fieldName");
+        validateNotEmpty(fieldName, FIELD_NAME_PARAM);
         return "set" + CaseUtils.toCamelCase(fieldName, true, '_');
     }
     
@@ -120,8 +126,8 @@ public final class NamingConventions {
      * Creates DAO method name.
      */
     public static String daoMethodName(String operation, String businessName) {
-        validateNotEmpty(operation, "operation");
-        validateNotEmpty(businessName, "businessName");
+        validateNotEmpty(operation, ProjectConstants.OPERATION_PARAM);
+        validateNotEmpty(businessName, ProjectConstants.BUSINESS_NAME_PARAM);
         return operation.toLowerCase() + businessName;
     }
     
@@ -129,8 +135,8 @@ public final class NamingConventions {
      * Creates controller endpoint method name.
      */
     public static String controllerMethodName(String operation, String businessName) {
-        validateNotEmpty(operation, "operation");
-        validateNotEmpty(businessName, "businessName");
+        validateNotEmpty(operation, ProjectConstants.OPERATION_PARAM);
+        validateNotEmpty(businessName, ProjectConstants.BUSINESS_NAME_PARAM);
         return operation.toLowerCase() + "DataFor" + businessName;
     }
     
@@ -140,7 +146,7 @@ public final class NamingConventions {
      * Converts column name to parameter name (camelCase).
      */
     public static String parameterName(String columnName) {
-        validateNotEmpty(columnName, "columnName");
+        validateNotEmpty(columnName, COLUMN_NAME_PARAM);
         return CaseUtils.toCamelCase(columnName, false, '_');
     }
     

--- a/src/main/java/com/jfeatures/msg/codegen/util/ParameterBuilders.java
+++ b/src/main/java/com/jfeatures/msg/codegen/util/ParameterBuilders.java
@@ -1,6 +1,7 @@
 package com.jfeatures.msg.codegen.util;
 
 import com.jfeatures.msg.codegen.SQLServerDataTypeEnum;
+import com.jfeatures.msg.codegen.constants.CodeGenerationConstants;
 import com.jfeatures.msg.codegen.dbmetadata.ColumnMetadata;
 import com.jfeatures.msg.codegen.domain.DBColumn;
 import com.squareup.javapoet.AnnotationSpec;
@@ -19,7 +20,14 @@ import org.springframework.web.bind.annotation.RequestParam;
  * Follows Single Responsibility Principle - only parameter creation logic.
  */
 public final class ParameterBuilders {
-    
+
+    private static final String TYPE_PARAM = "type";
+    private static final String PARAM_NAME_PARAM = "paramName";
+    private static final String REQUEST_PARAM_NAME_PARAM = "requestParamName";
+    private static final String PATH_VAR_NAME_PARAM = "pathVarName";
+    private static final String DTO_COLUMNS_PARAM = "dtoColumns";
+    private static final String DTO_PARAMETER_NAME_PARAM = "dtoParameterName";
+
     private ParameterBuilders() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
@@ -30,9 +38,9 @@ public final class ParameterBuilders {
      * Creates a @RequestParam parameter with default settings.
      */
     public static ParameterSpec requestParam(TypeName type, String paramName) {
-        validateNotNull(type, "type");
-        validateNotEmpty(paramName, "paramName");
-        
+        validateNotNull(type, TYPE_PARAM);
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
+
         return ParameterSpec.builder(type, paramName)
                 .addAnnotation(RequestParam.class)
                 .build();
@@ -42,13 +50,14 @@ public final class ParameterBuilders {
      * Creates a @RequestParam parameter with custom request parameter name.
      */
     public static ParameterSpec requestParamWithName(TypeName type, String paramName, String requestParamName) {
-        validateNotNull(type, "type");
-        validateNotEmpty(paramName, "paramName");
-        validateNotEmpty(requestParamName, "requestParamName");
-        
+        validateNotNull(type, TYPE_PARAM);
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
+        validateNotEmpty(requestParamName, REQUEST_PARAM_NAME_PARAM);
+
         return ParameterSpec.builder(type, paramName)
                 .addAnnotation(AnnotationSpec.builder(RequestParam.class)
-                        .addMember("value", "$S", requestParamName)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, requestParamName)
                         .build())
                 .build();
     }
@@ -57,17 +66,18 @@ public final class ParameterBuilders {
      * Creates an optional @RequestParam parameter.
      */
     public static ParameterSpec optionalRequestParam(TypeName type, String paramName, Object defaultValue) {
-        validateNotNull(type, "type");
-        validateNotEmpty(paramName, "paramName");
-        
+        validateNotNull(type, TYPE_PARAM);
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
+
         AnnotationSpec.Builder requestParamBuilder = AnnotationSpec.builder(RequestParam.class)
-                .addMember("required", "$L", false);
+                .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_REQUIRED,
+                        CodeGenerationConstants.LITERAL_PLACEHOLDER, false);
         
         if (defaultValue != null) {
             if (defaultValue instanceof String) {
-                requestParamBuilder.addMember("defaultValue", "$S", defaultValue);
+                requestParamBuilder.addMember("defaultValue", CodeGenerationConstants.STRING_PLACEHOLDER, defaultValue);
             } else {
-                requestParamBuilder.addMember("defaultValue", "$L", defaultValue);
+                requestParamBuilder.addMember("defaultValue", CodeGenerationConstants.LITERAL_PLACEHOLDER, defaultValue);
             }
         }
         
@@ -82,8 +92,8 @@ public final class ParameterBuilders {
      * Creates a @PathVariable parameter.
      */
     public static ParameterSpec pathVariable(TypeName type, String paramName) {
-        validateNotNull(type, "type");
-        validateNotEmpty(paramName, "paramName");
+        validateNotNull(type, TYPE_PARAM);
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
         
         return ParameterSpec.builder(type, paramName)
                 .addAnnotation(PathVariable.class)
@@ -94,13 +104,14 @@ public final class ParameterBuilders {
      * Creates a @PathVariable parameter with custom path variable name.
      */
     public static ParameterSpec pathVariableWithName(TypeName type, String paramName, String pathVarName) {
-        validateNotNull(type, "type");
-        validateNotEmpty(paramName, "paramName");
-        validateNotEmpty(pathVarName, "pathVarName");
-        
+        validateNotNull(type, TYPE_PARAM);
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
+        validateNotEmpty(pathVarName, PATH_VAR_NAME_PARAM);
+
         return ParameterSpec.builder(type, paramName)
                 .addAnnotation(AnnotationSpec.builder(PathVariable.class)
-                        .addMember("value", "$S", pathVarName)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, pathVarName)
                         .build())
                 .build();
     }
@@ -111,8 +122,8 @@ public final class ParameterBuilders {
      * Creates a @Valid @RequestBody parameter for DTO objects.
      */
     public static ParameterSpec validRequestBody(TypeName type, String paramName) {
-        validateNotNull(type, "type");
-        validateNotEmpty(paramName, "paramName");
+        validateNotNull(type, TYPE_PARAM);
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
         
         return ParameterSpec.builder(type, paramName)
                 .addAnnotation(Valid.class)
@@ -124,8 +135,8 @@ public final class ParameterBuilders {
      * Creates a simple @RequestBody parameter without validation.
      */
     public static ParameterSpec requestBody(TypeName type, String paramName) {
-        validateNotNull(type, "type");
-        validateNotEmpty(paramName, "paramName");
+        validateNotNull(type, TYPE_PARAM);
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
         
         return ParameterSpec.builder(type, paramName)
                 .addAnnotation(RequestBody.class)
@@ -153,7 +164,8 @@ public final class ParameterBuilders {
             
             if (asRequestParams) {
                 paramBuilder.addAnnotation(AnnotationSpec.builder(RequestParam.class)
-                        .addMember("value", "$S", paramName)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, paramName)
                         .build());
             }
             
@@ -181,7 +193,8 @@ public final class ParameterBuilders {
             
             if (asRequestParams) {
                 paramBuilder.addAnnotation(AnnotationSpec.builder(RequestParam.class)
-                        .addMember("value", "$S", paramName)
+                        .addMember(CodeGenerationConstants.ANNOTATION_MEMBER_VALUE,
+                                CodeGenerationConstants.STRING_PLACEHOLDER, paramName)
                         .build());
             }
             
@@ -211,8 +224,8 @@ public final class ParameterBuilders {
      */
     public static ParameterSpec idParameter(TypeName idType, String paramName) {
         validateNotNull(idType, "idType");
-        validateNotEmpty(paramName, "paramName");
-        
+        validateNotEmpty(paramName, PARAM_NAME_PARAM);
+
         return pathVariable(idType, paramName);
     }
     


### PR DESCRIPTION
## Summary
- centralize JavaPoet placeholders and annotation member names in `CodeGenerationConstants`
- update controllers and generation utilities to reuse shared constants instead of hard-coded annotation strings
- consolidate repeated literals in metadata extraction, SQL utilities, and file resolution logic

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to resolve spring-boot-maven-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cca62e84832aa345d86cb15eb5f6