### PR TITLE
Simplify TestUtils utilities to resolve sonar issues

### DIFF
--- a/src/test/java/com/jfeatures/msg/integration/CompleteScenarioCoverageTest.java
+++ b/src/test/java/com/jfeatures/msg/integration/CompleteScenarioCoverageTest.java
@@ -203,9 +203,6 @@ class CompleteScenarioCoverageTest {
         
         String businessDomainName = "Product";
         
-        // Setup mocks for INSERT scenario
-        TestUtils.setupInsertWorkflowMocks(mockDatabaseConnection, mockDataSource, mockNamedParameterJdbcTemplate);
-        
         // Setup database metadata mocks for INSERT metadata extraction
         DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
         when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
@@ -274,9 +271,6 @@ class CompleteScenarioCoverageTest {
         
         String businessDomainName = "CustomerUpdate";
         
-        // Setup mocks for UPDATE scenario
-        TestUtils.setupUpdateWorkflowMocks(mockDatabaseConnection, mockDataSource, mockNamedParameterJdbcTemplate);
-        
         // Setup database metadata mocks for UPDATE metadata extraction
         DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
         when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
@@ -334,9 +328,6 @@ class CompleteScenarioCoverageTest {
             """;
         
         String businessDomainName = "OrderItem";
-        
-        // Setup mocks for DELETE scenario
-        TestUtils.setupDeleteWorkflowMocks(mockDatabaseConnection, mockDataSource);
         
         // Mock ParameterMetadataExtractor for DELETE scenario
         try (var mockedConstruction = mockConstruction(ParameterMetadataExtractor.class, (mock, context) -> {

--- a/src/test/java/com/jfeatures/msg/integration/ComprehensiveCRUDWorkflowTest.java
+++ b/src/test/java/com/jfeatures/msg/integration/ComprehensiveCRUDWorkflowTest.java
@@ -130,10 +130,7 @@ class ComprehensiveCRUDWorkflowTest {
             VALUES (?, ?, ?, ?, ?)
             """;
         
-        // Setup database mocks for INSERT workflow
-        TestUtils.setupInsertWorkflowMocks(mockDatabaseConnection, mockDataSource, mockNamedParameterJdbcTemplate);
-        
-        // Setup database metadata mocking for INSERT (uses database metadata, not parameter metadata)
+        // Setup database metadata mocking for INSERT workflow (uses database metadata, not parameter metadata)
         when(mockDataSource.getConnection()).thenReturn(mockConnection);
         when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
         
@@ -193,9 +190,6 @@ class ComprehensiveCRUDWorkflowTest {
             SET order_status = ?, updated_date = ?, notes = ?
             WHERE order_id = ? AND customer_id = ?
             """;
-        
-        // Setup database mocks for UPDATE workflow
-        TestUtils.setupUpdateWorkflowMocks(mockDatabaseConnection, mockDataSource, mockNamedParameterJdbcTemplate);
         
         // Setup parameter metadata mocking for ParameterMetadataExtractor (UPDATE has 5 parameters)
         when(mockDataSource.getConnection()).thenReturn(mockConnection);
@@ -271,10 +265,7 @@ class ComprehensiveCRUDWorkflowTest {
             WHERE user_id = ? AND status = 'INACTIVE' AND last_login < ?
             """;
         
-        // Setup database mocks for DELETE workflow - need proper parameter metadata mocking
-        TestUtils.setupDeleteWorkflowMocks(mockDatabaseConnection, mockDataSource);
-        
-        // Setup parameter metadata mocking for ParameterMetadataExtractor
+        // Setup parameter metadata mocking for ParameterMetadataExtractor (DELETE workflow)
         when(mockDataSource.getConnection()).thenReturn(mockConnection);
         when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
         when(mockPreparedStatement.getParameterMetaData()).thenReturn(mockParameterMetaData);
@@ -329,10 +320,7 @@ class ComprehensiveCRUDWorkflowTest {
             AND c.customer_id = ?
             """;
         
-        // Setup database mocks for UPDATE workflow
-        TestUtils.setupUpdateWorkflowMocks(mockDatabaseConnection, mockDataSource, mockNamedParameterJdbcTemplate);
-        
-        // Setup database metadata mocking for UPDATE (uses database metadata, not parameter metadata)
+        // Setup database metadata mocking for UPDATE workflow (uses database metadata, not parameter metadata)
         when(mockDataSource.getConnection()).thenReturn(mockConnection);
         when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
         
@@ -412,10 +400,7 @@ class ComprehensiveCRUDWorkflowTest {
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
         
-        // Setup INSERT workflow mocks
-        TestUtils.setupInsertWorkflowMocks(mockDatabaseConnection, mockDataSource, mockNamedParameterJdbcTemplate);
-        
-        // Setup database metadata mocking for INSERT (uses database metadata, not parameter metadata)
+        // Setup database metadata mocking for INSERT workflow (uses database metadata, not parameter metadata)
         when(mockDataSource.getConnection()).thenReturn(mockConnection);
         when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
         
@@ -464,10 +449,7 @@ class ComprehensiveCRUDWorkflowTest {
         String businessDomainName = "Integration";
         String updateSql = "UPDATE test_table SET name = ?, description = ? WHERE id = ?";
         
-        // Setup UPDATE workflow mocks
-        TestUtils.setupUpdateWorkflowMocks(mockDatabaseConnection, mockDataSource, mockNamedParameterJdbcTemplate);
-        
-        // Setup database metadata mocking for UPDATE (uses database metadata, not parameter metadata)
+        // Setup database metadata mocking for UPDATE workflow (uses database metadata, not parameter metadata)
         when(mockDataSource.getConnection()).thenReturn(mockConnection);
         when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
         

--- a/src/test/java/com/jfeatures/msg/test/TestUtils.java
+++ b/src/test/java/com/jfeatures/msg/test/TestUtils.java
@@ -1,24 +1,10 @@
 package com.jfeatures.msg.test;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
-import com.jfeatures.msg.codegen.ParameterMetadataExtractor;
 import com.jfeatures.msg.codegen.dbmetadata.ColumnMetadata;
-import com.jfeatures.msg.codegen.dbmetadata.InsertMetadata;
-import com.jfeatures.msg.codegen.dbmetadata.UpdateMetadata;
-import com.jfeatures.msg.codegen.domain.DBColumn;
-import com.jfeatures.msg.codegen.domain.DatabaseConnection;
-import com.jfeatures.msg.controller.CodeGenController;
 import java.sql.Types;
-import java.util.Arrays;
-import java.util.List;
-import javax.sql.DataSource;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 /**
- * Utility class for test data creation and mock setup
+ * Utility class for creating database metadata objects used in tests.
  */
 public final class TestUtils {
 
@@ -27,9 +13,20 @@ public final class TestUtils {
     }
 
     /**
-     * Creates a ColumnMetadata object with proper initialization for testing
+     * Creates {@link ColumnMetadata} fully initialized for testing scenarios.
+     *
+     * @param columnName the database column name
+     * @param columnTypeName the database column type name
+     * @param columnType the {@link java.sql.Types} value representing the column type
+     * @param isNullable whether the column allows null values
+     * @return fully initialized {@link ColumnMetadata} instance for tests
      */
-    public static ColumnMetadata createColumnMetadata(String columnName, String columnTypeName, int columnType, boolean isNullable) {
+    public static ColumnMetadata createColumnMetadata(
+        String columnName,
+        String columnTypeName,
+        int columnType,
+        boolean isNullable
+    ) {
         ColumnMetadata metadata = new ColumnMetadata();
         metadata.setColumnName(columnName);
         metadata.setColumnTypeName(columnTypeName);
@@ -38,18 +35,9 @@ public final class TestUtils {
         metadata.setColumnClassName(getJavaTypeForSqlType(columnType));
         return metadata;
     }
-    
+
     /**
-     * Create ColumnMetadata with alias for testing
-     */
-    public static ColumnMetadata createColumnMetadataWithAlias(String columnName, String columnAlias, String columnTypeName, int columnType, boolean isNullable) {
-        ColumnMetadata metadata = createColumnMetadata(columnName, columnTypeName, columnType, isNullable);
-        metadata.setColumnAlias(columnAlias);
-        return metadata;
-    }
-    
-    /**
-     * Maps SQL types to Java class names for test data
+     * Maps {@link java.sql.Types} values to their corresponding Java class names used by tests.
      */
     private static String getJavaTypeForSqlType(int sqlType) {
         return switch (sqlType) {
@@ -67,144 +55,5 @@ public final class TestUtils {
             case Types.TINYINT -> "java.lang.Byte";
             default -> "java.lang.Object";
         };
-    }
-    
-    // Mock setup methods for integration tests
-    
-    public static void setupSelectWorkflowMocks(DatabaseConnection mockDatabaseConnection, JdbcTemplate mockJdbcTemplate) throws Exception {
-        // Mock column metadata for SELECT
-        List<ColumnMetadata> selectColumns = Arrays.asList(
-            createColumnMetadata("customer_id", "INT", Types.INTEGER, false),
-            createColumnMetadata("customer_name", "VARCHAR", Types.VARCHAR, true),
-            createColumnMetadata("email", "VARCHAR", Types.VARCHAR, true),
-            createColumnMetadata("phone", "VARCHAR", Types.VARCHAR, true),
-            createColumnMetadata("address", "VARCHAR", Types.VARCHAR, true),
-            createColumnMetadata("city", "VARCHAR", Types.VARCHAR, true),
-            createColumnMetadata("country", "VARCHAR", Types.VARCHAR, true)
-        );
-        
-        // Mock parameters for WHERE clause
-        List<DBColumn> whereParameters = Arrays.asList(
-            new DBColumn("table", "customerId", "INTEGER", "VARCHAR"),
-            new DBColumn("table", "status", "VARCHAR", "VARCHAR"),
-            new DBColumn("table", "createdDate", "TIMESTAMP", "VARCHAR")
-        );
-        
-        // Setup mocks - These should be handled by the calling test methods
-        // Static constructor mocking is complex and should be done in individual tests
-    }
-    
-    public static void setupInsertWorkflowMocks(DatabaseConnection mockDatabaseConnection, DataSource mockDataSource, NamedParameterJdbcTemplate mockNamedParameterJdbcTemplate) throws Exception {
-        // Mock insert metadata
-        List<ColumnMetadata> insertColumns = Arrays.asList(
-            createColumnMetadata("product_name", "VARCHAR", Types.VARCHAR, false),
-            createColumnMetadata("description", "TEXT", Types.LONGVARCHAR, true),
-            createColumnMetadata("price", "DECIMAL", Types.DECIMAL, false),
-            createColumnMetadata("category_id", "INT", Types.INTEGER, false),
-            createColumnMetadata("created_date", "TIMESTAMP", Types.TIMESTAMP, false)
-        );
-        
-        InsertMetadata mockInsertMetadata = new InsertMetadata("products", insertColumns, "INSERT INTO products...");
-        
-        // Mock extractor should be setup by calling test method
-    }
-    
-    public static void setupUpdateWorkflowMocks(DatabaseConnection mockDatabaseConnection, DataSource mockDataSource, NamedParameterJdbcTemplate mockNamedParameterJdbcTemplate) throws Exception {
-        // Mock update metadata
-        List<ColumnMetadata> setColumns = Arrays.asList(
-            createColumnMetadata("order_status", "VARCHAR", Types.VARCHAR, false),
-            createColumnMetadata("updated_date", "TIMESTAMP", Types.TIMESTAMP, false),
-            createColumnMetadata("notes", "TEXT", Types.LONGVARCHAR, true)
-        );
-        
-        List<ColumnMetadata> whereColumns = Arrays.asList(
-            createColumnMetadata("order_id", "INT", Types.INTEGER, false),
-            createColumnMetadata("customer_id", "INT", Types.INTEGER, false)
-        );
-        
-        UpdateMetadata mockUpdateMetadata = new UpdateMetadata("orders", setColumns, whereColumns, "UPDATE orders...");
-        
-        // Mock extractor should be setup by calling test method
-    }
-    
-    public static void setupDeleteWorkflowMocks(DatabaseConnection mockDatabaseConnection, DataSource mockDataSource) throws Exception {
-        // Mock delete parameters to match the DELETE SQL with 3 parameters
-        List<DBColumn> deleteParameters = Arrays.asList(
-            new DBColumn("table", "orderId", "INTEGER", "VARCHAR"),
-            new DBColumn("table", "productId", "INTEGER", "VARCHAR"),
-            new DBColumn("table", "createdDate", "TIMESTAMP", "VARCHAR")
-        );
-        
-        // Mock extractor should be setup by calling test method
-    }
-    
-    public static void setupComplexSelectWorkflowMocks(DatabaseConnection mockDatabaseConnection, JdbcTemplate mockJdbcTemplate) throws Exception {
-        // Mock complex query columns from multiple tables
-        List<ColumnMetadata> complexColumns = Arrays.asList(
-            createColumnMetadata("customer_id", "INT", Types.INTEGER, false),
-            createColumnMetadata("customer_name", "VARCHAR", Types.VARCHAR, false),
-            createColumnMetadata("email", "VARCHAR", Types.VARCHAR, true),
-            createColumnMetadata("order_id", "INT", Types.INTEGER, false),
-            createColumnMetadata("order_date", "DATE", Types.DATE, false),
-            createColumnMetadata("total_amount", "DECIMAL", Types.DECIMAL, false),
-            createColumnMetadata("item_id", "INT", Types.INTEGER, false),
-            createColumnMetadata("product_name", "VARCHAR", Types.VARCHAR, false),
-            createColumnMetadata("quantity", "INT", Types.INTEGER, false),
-            createColumnMetadata("unit_price", "DECIMAL", Types.DECIMAL, false)
-        );
-        
-        List<DBColumn> complexParameters = Arrays.asList(
-            new DBColumn("table", "customerId", "INTEGER", "VARCHAR"),
-            new DBColumn("table", "orderDate", "DATE", "VARCHAR"),
-            new DBColumn("table", "orderStatus", "VARCHAR", "VARCHAR"),
-            new DBColumn("table", "quantity", "INTEGER", "VARCHAR")
-        );
-        
-        // Setup complex mocks - create mock objects directly instead of static constructor mocking
-        CodeGenController mockController = mock(CodeGenController.class);
-        when(mockController.selectColumnMetadata()).thenReturn(complexColumns);
-        
-        ParameterMetadataExtractor mockExtractor = mock(ParameterMetadataExtractor.class);
-        when(mockExtractor.extractParameters(anyString())).thenReturn(complexParameters);
-    }
-    
-    public static void setupMultipleDataTypesWorkflowMocks(DatabaseConnection mockDatabaseConnection, JdbcTemplate mockJdbcTemplate) throws Exception {
-        // Mock various data types
-        List<ColumnMetadata> dataTypeColumns = Arrays.asList(
-            createColumnMetadata("id", "INT", Types.INTEGER, false),
-            createColumnMetadata("name", "VARCHAR", Types.VARCHAR, false),
-            createColumnMetadata("description", "TEXT", Types.LONGVARCHAR, true),
-            createColumnMetadata("price", "DECIMAL", Types.DECIMAL, false),
-            createColumnMetadata("quantity", "INT", Types.INTEGER, false),
-            createColumnMetadata("is_active", "BIT", Types.BIT, false),
-            createColumnMetadata("created_date", "DATE", Types.DATE, false),
-            createColumnMetadata("updated_timestamp", "TIMESTAMP", Types.TIMESTAMP, true),
-            createColumnMetadata("category_code", "CHAR", Types.CHAR, true),
-            createColumnMetadata("discount_rate", "FLOAT", Types.FLOAT, true),
-            createColumnMetadata("image_data", "BLOB", Types.BLOB, true)
-        );
-        
-        List<DBColumn> dataTypeParameters = Arrays.asList(
-            new DBColumn("table", "minPrice", "DECIMAL", "VARCHAR"),
-            new DBColumn("table", "maxPrice", "DECIMAL", "VARCHAR"),
-            new DBColumn("table", "createdDate", "DATE", "VARCHAR"),
-            new DBColumn("table", "isActive", "BIT", "VARCHAR")
-        );
-        
-        // Setup data type mocks should be done by calling test method
-    }
-    
-    public static void setupCompleteWorkflowMocks(DatabaseConnection mockDatabaseConnection, JdbcTemplate mockJdbcTemplate, DataSource mockDataSource) throws Exception {
-        // Simple integration test mocks
-        List<ColumnMetadata> simpleColumns = Arrays.asList(
-            createColumnMetadata("id", "INT", Types.INTEGER, false),
-            createColumnMetadata("name", "VARCHAR", Types.VARCHAR, false)
-        );
-        
-        List<DBColumn> simpleParameters = Arrays.asList(
-            new DBColumn("table", "id", "INTEGER", "VARCHAR")
-        );
-        
-        // Setup simple workflow mocks should be done by calling test method
     }
 }


### PR DESCRIPTION
## Summary
- streamline `TestUtils` to focus on column metadata creation and remove unused mocking helpers causing Sonar complaints
- update integration tests to drop calls to the deleted helpers and clarify the metadata mocking that remains

## Testing
- mvn -q test *(fails: unable to reach repo.maven.apache.org to download spring-boot-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cd339e34832ab90886e3e723f9bd