### PR TITLE
Refine AssertJ usage and stabilize exception tests

### DIFF
--- a/src/test/java/com/jfeatures/msg/codegen/GenerateControllerTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateControllerTest.java
@@ -21,9 +21,10 @@ class GenerateControllerTest {
         JavaFile result = GenerateController.createController("Customer", predicateLiterals);
 
         // Then
-        assertThat(result).isNotNull();
-        assertThat(result.packageName).isEqualTo("com.jfeatures.msg.customer.controller");
-        assertThat(result.typeSpec.name).isEqualTo("CustomerController");
+        assertThat(result)
+            .isNotNull()
+            .returns("com.jfeatures.msg.customer.controller", javaFile -> javaFile.packageName)
+            .returns("CustomerController", javaFile -> javaFile.typeSpec.name);
         
         String generatedCode = result.toString();
         assertThat(generatedCode)
@@ -103,8 +104,9 @@ class GenerateControllerTest {
         JavaFile result = GenerateController.createController("QuarterlySalesReport", predicateLiterals);
 
         // Then
-        assertThat(result.typeSpec.name).isEqualTo("QuarterlySalesReportController");
-        assertThat(result.packageName).isEqualTo("com.jfeatures.msg.quarterlysalesreport.controller");
+        assertThat(result)
+            .returns("QuarterlySalesReportController", javaFile -> javaFile.typeSpec.name)
+            .returns("com.jfeatures.msg.quarterlysalesreport.controller", javaFile -> javaFile.packageName);
         
         String generatedCode = result.toString();
         assertThat(generatedCode)

--- a/src/test/java/com/jfeatures/msg/codegen/GenerateDAOTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateDAOTest.java
@@ -31,9 +31,10 @@ class GenerateDAOTest {
         JavaFile result = GenerateDAO.createDaoFromMetadata("Customer", columnMetadata, predicateLiterals, sql);
 
         // Then
-        assertThat(result).isNotNull();
-        assertThat(result.packageName).isEqualTo("com.jfeatures.msg.customer.dao");
-        assertThat(result.typeSpec.name).isEqualTo("CustomerDAO");
+        assertThat(result)
+            .isNotNull()
+            .returns("com.jfeatures.msg.customer.dao", javaFile -> javaFile.packageName)
+            .returns("CustomerDAO", javaFile -> javaFile.typeSpec.name);
         
         String generatedCode = result.toString();
         assertThat(generatedCode)
@@ -108,9 +109,10 @@ class GenerateDAOTest {
 
         // Then
         assertThat(result)
-            .isNotNull();
-        assertThat(result.typeSpec.name).isEqualTo(businessPurpose + "DAO");
-        assertThat(result.packageName).isEqualTo("com.jfeatures.msg." + businessPurpose.toLowerCase() + ".dao");
+            .isNotNull()
+            .returns(businessPurpose + "DAO", javaFile -> javaFile.typeSpec.name)
+            .returns("com.jfeatures.msg." + businessPurpose.toLowerCase() + ".dao",
+                javaFile -> javaFile.packageName);
     }
 
     @Test
@@ -138,7 +140,8 @@ class GenerateDAOTest {
             .hasMessageContaining("Select column metadata cannot be null");
 
         // Test empty column metadata
-        assertThatThrownBy(() -> GenerateDAO.createDaoFromMetadata("Test", Arrays.asList(), validPredicateLiterals, validSQL))
+        List<ColumnMetadata> emptyColumnMetadata = Arrays.asList();
+        assertThatThrownBy(() -> GenerateDAO.createDaoFromMetadata("Test", emptyColumnMetadata, validPredicateLiterals, validSQL))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Select column metadata cannot be empty");
 

--- a/src/test/java/com/jfeatures/msg/codegen/GenerateDTOTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateDTOTest.java
@@ -26,9 +26,10 @@ class GenerateDTOTest {
         JavaFile result = GenerateDTO.dtoFromColumnMetadata(columnMetadata, "Customer");
 
         // Then
-        assertThat(result).isNotNull();
-        assertThat(result.packageName).isEqualTo("com.jfeatures.msg.customer.dto");
-        assertThat(result.typeSpec.name).isEqualTo("CustomerDTO");
+        assertThat(result)
+            .isNotNull()
+            .returns("com.jfeatures.msg.customer.dto", javaFile -> javaFile.packageName)
+            .returns("CustomerDTO", javaFile -> javaFile.typeSpec.name);
         
         String generatedCode = result.toString();
         assertThat(generatedCode)
@@ -85,8 +86,10 @@ class GenerateDTOTest {
         JavaFile result = GenerateDTO.dtoFromColumnMetadata(columnMetadata, businessPurpose);
 
         // Then
-        assertThat(result.typeSpec.name).isEqualTo(businessPurpose + "DTO");
-        assertThat(result.packageName).isEqualTo("com.jfeatures.msg." + businessPurpose.toLowerCase() + ".dto");
+        assertThat(result)
+            .returns(businessPurpose + "DTO", javaFile -> javaFile.typeSpec.name)
+            .returns("com.jfeatures.msg." + businessPurpose.toLowerCase() + ".dto",
+                javaFile -> javaFile.packageName);
     }
 
     @Test
@@ -98,8 +101,9 @@ class GenerateDTOTest {
         JavaFile result = GenerateDTO.dtoFromColumnMetadata(emptyColumnMetadata, "Empty");
 
         // Then
-        assertThat(result).isNotNull();
-        assertThat(result.typeSpec.fieldSpecs).isEmpty();
+        assertThat(result)
+            .isNotNull()
+            .returns(java.util.Collections.emptyList(), javaFile -> javaFile.typeSpec.fieldSpecs);
     }
 
     @Test

--- a/src/test/java/com/jfeatures/msg/codegen/MicroServiceGeneratorTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/MicroServiceGeneratorTest.java
@@ -186,8 +186,9 @@ class MicroServiceGeneratorTest {
         var mainMethod = clazz.getMethod("main", String[].class);
 
         // Then
-        assertThat(mainMethod).isNotNull();
-        assertThat(mainMethod.getReturnType()).isEqualTo(void.class);
+        assertThat(mainMethod)
+            .isNotNull()
+            .returns(void.class, java.lang.reflect.Method::getReturnType);
     }
 
     @Test
@@ -199,8 +200,9 @@ class MicroServiceGeneratorTest {
         var getSqlMethod = clazz.getMethod("getSql", String.class);
 
         // Then
-        assertThat(getSqlMethod).isNotNull();
-        assertThat(getSqlMethod.getReturnType()).isEqualTo(String.class);
+        assertThat(getSqlMethod)
+            .isNotNull()
+            .returns(String.class, java.lang.reflect.Method::getReturnType);
     }
 
     // New tests to improve coverage for call() and validateInputParameters() methods

--- a/src/test/java/com/jfeatures/msg/codegen/util/SqlBuildersTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/util/SqlBuildersTest.java
@@ -78,8 +78,9 @@ class SqlBuildersTest {
         @Test
         @DisplayName("buildInsertSql should throw exception for empty columns")
         void buildInsertSql_ShouldThrowExceptionForEmptyColumns() {
+            List<ColumnMetadata> emptyColumns = new ArrayList<>();
             assertThrows(IllegalArgumentException.class, () ->
-                SqlBuilders.buildInsertSql("users", new ArrayList<>())
+                SqlBuilders.buildInsertSql("users", emptyColumns)
             );
         }
 
@@ -173,8 +174,9 @@ class SqlBuildersTest {
         @Test
         @DisplayName("buildDeleteSql should throw exception for empty whereColumns")
         void buildDeleteSql_ShouldThrowExceptionForEmptyWhereColumns() {
+            List<ColumnMetadata> emptyWhereColumns = new ArrayList<>();
             assertThrows(IllegalArgumentException.class, () ->
-                SqlBuilders.buildDeleteSql("users", new ArrayList<>())
+                SqlBuilders.buildDeleteSql("users", emptyWhereColumns)
             );
         }
     }


### PR DESCRIPTION
## Summary
- chain consecutive AssertJ assertions in controller, DAO, DTO, and CLI generator tests using returns checks to satisfy Sonar rule S5853
- move list constructions outside of exception assertion lambdas to remove extra invocations flagged by S5778

## Testing
- `mvn -q -DskipITs test` *(fails: unable to download spring-boot-maven-plugin because the Maven Central repository is unreachable from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a62c0aa8832a853869a13e29e7f5