### PR TITLE
Replace Lombok logging in generator classes

### DIFF
--- a/src/main/java/com/jfeatures/msg/codegen/GenerateDeleteDAO.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateDeleteDAO.java
@@ -18,16 +18,18 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.lang.model.element.Modifier;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.CaseUtils;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generates DAO classes for DELETE operations.
  * Following Vipin's Principle: Single responsibility - DELETE DAO generation only.
  */
-@Slf4j
 public class GenerateDeleteDAO {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateDeleteDAO.class);
 
     private GenerateDeleteDAO() {
         throw new UnsupportedOperationException("Utility class");
@@ -89,7 +91,7 @@ public class GenerateDeleteDAO {
         JavaFile javaFile = JavaFile.builder(JavaPackageNameBuilder.buildJavaPackageName(businessPurposeOfSQL, "dao"), dao)
                 .build();
         
-        log.info(javaFile.toString());
+        LOGGER.info(javaFile.toString());
         
         return javaFile;
     }

--- a/src/main/java/com/jfeatures/msg/codegen/GenerateInsertController.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateInsertController.java
@@ -19,10 +19,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import javax.lang.model.element.Modifier;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.CaseUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,8 +33,9 @@ import org.springframework.web.bind.annotation.RestController;
  * Generates REST Controller with POST endpoints for INSERT operations.
  * Following Vipin's Principle: Single responsibility - INSERT controller generation only.
  */
-@Slf4j
 public class GenerateInsertController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateInsertController.class);
 
     private GenerateInsertController() {
         throw new UnsupportedOperationException("Utility class");
@@ -124,7 +126,7 @@ public class GenerateInsertController {
         JavaFile javaFile = JavaFile.builder(JavaPackageNameBuilder.buildJavaPackageName(businessPurposeOfSQL, "controller"), controller)
                 .build();
         
-        log.info(javaFile.toString());
+        LOGGER.info(javaFile.toString());
         
         return javaFile;
     }

--- a/src/main/java/com/jfeatures/msg/codegen/GenerateInsertDAO.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateInsertDAO.java
@@ -21,16 +21,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.lang.model.element.Modifier;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.CaseUtils;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generates DAO classes for INSERT operations.
  * Following Vipin's Principle: Single responsibility - INSERT DAO generation only.
  */
-@Slf4j
 public class GenerateInsertDAO {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateInsertDAO.class);
 
     private GenerateInsertDAO() {
         throw new UnsupportedOperationException("Utility class");
@@ -85,7 +87,7 @@ public class GenerateInsertDAO {
         JavaFile javaFile = JavaFile.builder(JavaPackageNameBuilder.buildJavaPackageName(businessPurposeOfSQL, "dao"), dao)
                 .build();
         
-        log.info(javaFile.toString());
+        LOGGER.info(javaFile.toString());
         
         return javaFile;
     }

--- a/src/main/java/com/jfeatures/msg/codegen/GenerateUpdateDAO.java
+++ b/src/main/java/com/jfeatures/msg/codegen/GenerateUpdateDAO.java
@@ -24,12 +24,15 @@ import javax.lang.model.element.Modifier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.CaseUtils;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generates DAO classes for UPDATE operations using database metadata.
  */
-@Slf4j
 public class GenerateUpdateDAO {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateUpdateDAO.class);
 
     private GenerateUpdateDAO() {
         throw new UnsupportedOperationException("Utility class");
@@ -69,7 +72,7 @@ public class GenerateUpdateDAO {
         JavaFile javaFile = JavaFile.builder(JavaPackageNameBuilder.buildJavaPackageName(businessPurposeOfSQL, "dao"), daoClass)
                 .build();
 
-        log.info(javaFile.toString());
+        LOGGER.info(javaFile.toString());
         return javaFile;
     }
     


### PR DESCRIPTION
## Summary
- replace Lombok `@Slf4j` usage in the DAO/controller generators with explicit SLF4J logger fields
- keep Lombok available only for generated code decorations while our utilities now log via `Logger`

## Testing
- `javac -cp $CLASSPATH -d target/classes $(find src/main/java -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68d4ae86f358832a98d8cc7fdb0c462b