### PR TITLE
Fix ReDoS vulnerability in ParameterMetadataExtractor regex

### DIFF
--- a/src/main/java/com/jfeatures/msg/codegen/ParameterMetadataExtractor.java
+++ b/src/main/java/com/jfeatures/msg/codegen/ParameterMetadataExtractor.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ParameterMetadataExtractor {
 
     private static final int MAX_SQL_LENGTH = 10_000;
-    private static final Pattern COLUMN_PATTERN = Pattern.compile("(\\w+\\.\\w+|\\w+)\\s*=\\s*\\?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern COLUMN_PATTERN = Pattern.compile("(\\w++(?:\\.\\w++)?+)\\s*+=\\s*+\\?", Pattern.CASE_INSENSITIVE);
     private static final Pattern WHERE_PATTERN = Pattern.compile("\\bwhere\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final String SQL_QUERY_TOO_LONG_MESSAGE = "SQL query too long";


### PR DESCRIPTION
## Summary
Fixed Regular Expression Denial of Service (ReDoS) vulnerability in `ParameterMetadataExtractor` by using possessive quantifiers throughout the regex pattern.

### Changes
- **Before:** `(\w+\.\w+|\w+)\s*=\s*\?`
- **After:** `(\w++(?:\.\w++)?+)\s*+=\s*+\?`

### Why This Works
The fix uses **possessive quantifiers** (`++`) which prevent backtracking completely:
- `\w++` - matches word characters without backtracking
- `(?:\.\w++)?+` - possessive optional group with possessive inner match
- `\s*+` - possessive whitespace matching

This eliminates the polynomial runtime vulnerability while maintaining identical functionality.

### Technical Explanation
Possessive quantifiers commit to their matches immediately and never backtrack, making catastrophic backtracking impossible. This is the recommended approach for preventing ReDoS in complex patterns.

## Test plan
- [x] All 28 existing ParameterMetadataExtractorTest tests pass
- [x] Regex functionality unchanged (matches same patterns)
- [x] No performance regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)