### PR TITLE
Fix column pattern to prevent regex backtracking

### DIFF
--- a/src/main/java/com/jfeatures/msg/codegen/ParameterMetadataExtractor.java
+++ b/src/main/java/com/jfeatures/msg/codegen/ParameterMetadataExtractor.java
@@ -18,7 +18,10 @@ import lombok.extern.slf4j.Slf4j;
 public class ParameterMetadataExtractor {
 
     private static final int MAX_SQL_LENGTH = 10_000;
-    private static final Pattern COLUMN_PATTERN = Pattern.compile("(\\w+(?:\\.\\w+)?)\\s*+=\\s*+\\?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern COLUMN_PATTERN = Pattern.compile(
+        "([A-Za-z0-9_]+\\.[A-Za-z0-9_]+|[A-Za-z0-9_]+)\\s*=\\s*\\?",
+        Pattern.CASE_INSENSITIVE
+    );
     private static final Pattern WHERE_PATTERN = Pattern.compile("\\bwhere\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final String SQL_QUERY_TOO_LONG_MESSAGE = "SQL query too long";


### PR DESCRIPTION
## Summary
- replace the column matching regex with an alternation-based pattern to avoid pathological backtracking while still supporting qualified columns

## Testing
- mvn -q -DskipITs test

------
https://chatgpt.com/codex/tasks/task_e_68de5ab61a20832aa9b16de6834e4e3a