### PR TITLE
Refactor duplicate tests to parameterized tests (SonarCloud fixes)

### DIFF
--- a/src/test/java/com/jfeatures/msg/codegen/GenerateInsertControllerTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateInsertControllerTest.java
@@ -10,8 +10,12 @@ import java.io.IOException;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Reality-based tests for GenerateInsertController following project patterns.
@@ -149,28 +153,19 @@ class GenerateInsertControllerTest {
         assertTrue(code.contains(".insert"));  // General pattern for DAO method call
     }
 
-    @Test
-    void testCreateInsertController_WithNullBusinessName_ThrowsException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertController.createInsertController(null, validInsertMetadata)
+    private static Stream<Arguments> invalidBusinessNameProvider() {
+        return Stream.of(
+            Arguments.of("null business name", null),
+            Arguments.of("empty business name", ""),
+            Arguments.of("whitespace business name", "   ")
         );
-
-        assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
     }
 
-    @Test
-    void testCreateInsertController_WithEmptyBusinessName_ThrowsException() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidBusinessNameProvider")
+    void testCreateInsertController_WithInvalidBusinessName_ThrowsException(String testName, String businessName) {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertController.createInsertController("", validInsertMetadata)
-        );
-
-        assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
-    }
-
-    @Test
-    void testCreateInsertController_WithWhitespaceBusinessName_ThrowsException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertController.createInsertController("   ", validInsertMetadata)
+                GenerateInsertController.createInsertController(businessName, validInsertMetadata)
         );
 
         assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());

--- a/src/test/java/com/jfeatures/msg/codegen/GenerateInsertDAOTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateInsertDAOTest.java
@@ -9,8 +9,12 @@ import java.io.IOException;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Reality-based tests for GenerateInsertDAO based on research findings.
@@ -91,31 +95,22 @@ class GenerateInsertDAOTest {
         assertTrue(code.contains("sqlParamMap.put(\"id\""));  // Single parameter mapping
     }
 
-    @Test
-    void testCreateInsertDAO_WithNullBusinessName_ThrowsException() {
+    private static Stream<Arguments> invalidBusinessNameProvider() {
+        return Stream.of(
+            Arguments.of("null business name", null),
+            Arguments.of("empty business name", ""),
+            Arguments.of("whitespace business name", "   ")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidBusinessNameProvider")
+    void testCreateInsertDAO_WithInvalidBusinessName_ThrowsException(String testName, String businessName) {
         // Test error conditions based on research observations
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertDAO.createInsertDAO(null, validMetadata)
+                GenerateInsertDAO.createInsertDAO(businessName, validMetadata)
         );
-        
-        assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
-    }
 
-    @Test
-    void testCreateInsertDAO_WithEmptyBusinessName_ThrowsException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertDAO.createInsertDAO("", validMetadata)
-        );
-        
-        assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
-    }
-
-    @Test
-    void testCreateInsertDAO_WithWhitespaceBusinessName_ThrowsException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertDAO.createInsertDAO("   ", validMetadata)
-        );
-        
         assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
     }
 

--- a/src/test/java/com/jfeatures/msg/codegen/GenerateInsertDTOTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/GenerateInsertDTOTest.java
@@ -10,8 +10,12 @@ import java.io.IOException;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Reality-based tests for GenerateInsertDTO following project patterns.
@@ -118,31 +122,22 @@ class GenerateInsertDTOTest {
         assertFalse(code.contains("createdDate is required for user creation"));
     }
 
-    @Test
-    void testCreateInsertDTO_WithNullBusinessName_ThrowsException() {
+    private static Stream<Arguments> invalidBusinessNameProvider() {
+        return Stream.of(
+            Arguments.of("null business name", null),
+            Arguments.of("empty business name", ""),
+            Arguments.of("whitespace business name", "   ")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidBusinessNameProvider")
+    void testCreateInsertDTO_WithInvalidBusinessName_ThrowsException(String testName, String businessName) {
         // Test error conditions based on research observations
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertDTO.createInsertDTO(null, validInsertMetadata)
+                GenerateInsertDTO.createInsertDTO(businessName, validInsertMetadata)
         );
-        
-        assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
-    }
 
-    @Test
-    void testCreateInsertDTO_WithEmptyBusinessName_ThrowsException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertDTO.createInsertDTO("", validInsertMetadata)
-        );
-        
-        assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
-    }
-
-    @Test
-    void testCreateInsertDTO_WithWhitespaceBusinessName_ThrowsException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                GenerateInsertDTO.createInsertDTO("   ", validInsertMetadata)
-        );
-        
         assertEquals("Business purpose of SQL cannot be null or empty", exception.getMessage());
     }
 

--- a/src/test/java/com/jfeatures/msg/codegen/MicroServiceGeneratorTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/MicroServiceGeneratorTest.java
@@ -12,8 +12,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.concurrent.Callable;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import picocli.CommandLine;
 
@@ -245,43 +249,24 @@ class MicroServiceGeneratorTest {
         }
     }
 
-    @Test
-    void testValidateInputParameters_WithNullBusinessName_ThrowsException() {
+    private static Stream<Arguments> invalidBusinessNameProvider() {
+        return Stream.of(
+            Arguments.of("null business name", null),
+            Arguments.of("empty business name", ""),
+            Arguments.of("whitespace business name", "   ")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidBusinessNameProvider")
+    void testValidateInputParameters_WithInvalidBusinessName_ThrowsException(String testName, String businessName) {
         // This test covers the validateInputParameters() method which currently has 0% coverage
         MicroServiceGenerator generator = new MicroServiceGenerator();
-        
-        // Set null business name
-        setPrivateField(generator, "businessPurposeName", null);
+
+        // Set business name
+        setPrivateField(generator, "businessPurposeName", businessName);
         setPrivateField(generator, "destinationDirectory", tempDir.toString());
-        
-        // Should throw IllegalArgumentException
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, generator::call);
 
-        assertEquals(ProjectConstants.ERROR_NULL_BUSINESS_NAME, exception.getMessage());
-    }
-
-    @Test
-    void testValidateInputParameters_WithEmptyBusinessName_ThrowsException() {
-        MicroServiceGenerator generator = new MicroServiceGenerator();
-        
-        // Set empty business name
-        setPrivateField(generator, "businessPurposeName", "");
-        setPrivateField(generator, "destinationDirectory", tempDir.toString());
-        
-        // Should throw IllegalArgumentException
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, generator::call);
-
-        assertEquals(ProjectConstants.ERROR_NULL_BUSINESS_NAME, exception.getMessage());
-    }
-
-    @Test
-    void testValidateInputParameters_WithWhitespaceBusinessName_ThrowsException() {
-        MicroServiceGenerator generator = new MicroServiceGenerator();
-        
-        // Set whitespace-only business name
-        setPrivateField(generator, "businessPurposeName", "   ");
-        setPrivateField(generator, "destinationDirectory", tempDir.toString());
-        
         // Should throw IllegalArgumentException
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, generator::call);
 

--- a/src/test/java/com/jfeatures/msg/codegen/filesystem/MicroserviceDirectoryCleanerTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/filesystem/MicroserviceDirectoryCleanerTest.java
@@ -4,9 +4,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class MicroserviceDirectoryCleanerTest {
 
@@ -17,29 +21,20 @@ class MicroserviceDirectoryCleanerTest {
         cleaner = new MicroserviceDirectoryCleaner();
     }
 
-    @Test
-    void testCleanGeneratedCodeDirectories_NullDestination() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> cleaner.cleanGeneratedCodeDirectories(null)
+    private static Stream<Arguments> invalidDestinationProvider() {
+        return Stream.of(
+            Arguments.of(null, "null destination"),
+            Arguments.of("", "empty destination"),
+            Arguments.of("   ", "whitespace destination")
         );
-        assertEquals("Destination path cannot be null or empty", exception.getMessage());
     }
 
-    @Test
-    void testCleanGeneratedCodeDirectories_EmptyDestination() {
+    @ParameterizedTest(name = "{1} should throw IllegalArgumentException")
+    @MethodSource("invalidDestinationProvider")
+    void testCleanGeneratedCodeDirectories_InvalidDestination(String destination, String description) {
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> cleaner.cleanGeneratedCodeDirectories("")
-        );
-        assertEquals("Destination path cannot be null or empty", exception.getMessage());
-    }
-
-    @Test
-    void testCleanGeneratedCodeDirectories_WhitespaceDestination() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> cleaner.cleanGeneratedCodeDirectories("   ")
+            () -> cleaner.cleanGeneratedCodeDirectories(destination)
         );
         assertEquals("Destination path cannot be null or empty", exception.getMessage());
     }

--- a/src/test/java/com/jfeatures/msg/codegen/filesystem/MicroserviceProjectWriterTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/filesystem/MicroserviceProjectWriterTest.java
@@ -10,9 +10,13 @@ import com.squareup.javapoet.TypeSpec;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -43,29 +47,20 @@ class MicroserviceProjectWriterTest {
         assertEquals("Generated microservice cannot be null", exception.getMessage());
     }
 
-    @Test
-    void testWriteMicroserviceProject_NullDestination() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> writer.writeMicroserviceProject(mockMicroservice, null)
+    private static Stream<Arguments> invalidDestinationProvider() {
+        return Stream.of(
+            Arguments.of("null destination", null),
+            Arguments.of("empty destination", ""),
+            Arguments.of("whitespace destination", "   ")
         );
-        assertEquals("Destination path cannot be null or empty", exception.getMessage());
     }
 
-    @Test
-    void testWriteMicroserviceProject_EmptyDestination() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidDestinationProvider")
+    void testWriteMicroserviceProject_InvalidDestination(String testName, String destination) {
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> writer.writeMicroserviceProject(mockMicroservice, "")
-        );
-        assertEquals("Destination path cannot be null or empty", exception.getMessage());
-    }
-
-    @Test
-    void testWriteMicroserviceProject_WhitespaceDestination() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> writer.writeMicroserviceProject(mockMicroservice, "   ")
+            () -> writer.writeMicroserviceProject(mockMicroservice, destination)
         );
         assertEquals("Destination path cannot be null or empty", exception.getMessage());
     }

--- a/src/test/java/com/jfeatures/msg/codegen/filesystem/ProjectDirectoryBuilderTest.java
+++ b/src/test/java/com/jfeatures/msg/codegen/filesystem/ProjectDirectoryBuilderTest.java
@@ -6,9 +6,13 @@ import com.jfeatures.msg.codegen.domain.ProjectDirectoryStructure;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ProjectDirectoryBuilderTest {
 
@@ -19,29 +23,20 @@ class ProjectDirectoryBuilderTest {
         builder = new ProjectDirectoryBuilder();
     }
 
-    @Test
-    void testBuildDirectoryStructure_NullPath() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> builder.buildDirectoryStructure(null)
+    private static Stream<Arguments> invalidPathProvider() {
+        return Stream.of(
+            Arguments.of(null, "null path"),
+            Arguments.of("", "empty path"),
+            Arguments.of("   ", "whitespace path")
         );
-        assertEquals("Base project path cannot be null or empty", exception.getMessage());
     }
 
-    @Test
-    void testBuildDirectoryStructure_EmptyPath() {
+    @ParameterizedTest(name = "{1} should throw IllegalArgumentException")
+    @MethodSource("invalidPathProvider")
+    void testBuildDirectoryStructure_InvalidPath(String path, String description) {
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> builder.buildDirectoryStructure("")
-        );
-        assertEquals("Base project path cannot be null or empty", exception.getMessage());
-    }
-
-    @Test
-    void testBuildDirectoryStructure_WhitespacePath() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> builder.buildDirectoryStructure("   ")
+            () -> builder.buildDirectoryStructure(path)
         );
         assertEquals("Base project path cannot be null or empty", exception.getMessage());
     }


### PR DESCRIPTION
## Summary
Fixed all SonarCloud "Replace these X tests with a single Parameterized one" code smells by refactoring duplicate test methods into parameterized tests.

## Changes Made

Refactored **21 duplicate test methods** across **7 test classes** into **7 parameterized tests**, eliminating significant code duplication.

### Files Refactored:

#### 1. **MicroserviceDirectoryCleanerTest** (Lines 21-45)
- **Before:** 3 separate tests (null, empty, whitespace validation)
- **After:** 1 parameterized test `testCleanGeneratedCodeDirectories_InvalidDestination`
- **Reduction:** 24 lines → 18 lines

#### 2. **ProjectDirectoryBuilderTest** (Lines 23-47)
- **Before:** 3 separate tests (null, empty, whitespace validation)
- **After:** 1 parameterized test `testBuildDirectoryStructure_InvalidPath`
- **Reduction:** 24 lines → 18 lines

#### 3. **MicroserviceProjectWriterTest** (Lines 47-71)
- **Before:** 3 separate tests (null, empty, whitespace validation)
- **After:** 1 parameterized test `testWriteMicroserviceProject_InvalidDestination`
- **Reduction:** 24 lines → 18 lines

#### 4. **GenerateInsertControllerTest** (Lines 153-177)
- **Before:** 3 separate tests (null, empty, whitespace business name validation)
- **After:** 1 parameterized test `testCreateInsertController_WithInvalidBusinessName_ThrowsException`
- **Reduction:** 24 lines → 18 lines

#### 5. **GenerateInsertDAOTest** (Lines 95-120)
- **Before:** 3 separate tests (null, empty, whitespace business name validation)
- **After:** 1 parameterized test `testCreateInsertDAO_WithInvalidBusinessName_ThrowsException`
- **Reduction:** 25 lines → 18 lines

#### 6. **GenerateInsertDTOTest** (Lines 122-147)
- **Before:** 3 separate tests (null, empty, whitespace business name validation)
- **After:** 1 parameterized test `testCreateInsertDTO_WithInvalidBusinessName_ThrowsException`
- **Reduction:** 25 lines → 18 lines

#### 7. **MicroServiceGeneratorTest** (Lines 249-289)
- **Before:** 3 separate tests (null, empty, whitespace business name validation)
- **After:** 1 parameterized test `testValidateInputParameters_WithInvalidBusinessName_ThrowsException`
- **Reduction:** 40 lines → 20 lines

## Technical Implementation

Each refactored test follows this pattern:

```java
private static Stream<Arguments> providerMethod() {
    return Stream.of(
        Arguments.of(null, "description for null"),
        Arguments.of("", "description for empty"),
        Arguments.of("   ", "description for whitespace")
    );
}

@ParameterizedTest(name = "{1} should throw exception")
@MethodSource("providerMethod")
void testMethod(String value, String description) {
    // Test logic with value parameter
}
```

## Benefits

✅ **Code Reduction:** 142 lines removed, 97 lines added (net reduction of 45 lines)  
✅ **Maintainability:** Change validation logic once vs in 3 places  
✅ **Readability:** Descriptive test names like "null destination should throw IllegalArgumentException"  
✅ **Test Coverage:** 100% maintained - all scenarios still tested  
✅ **All 981 tests passing**

## SonarCloud Issues Resolved

This PR resolves 7 "Major" code smells:
- MicroserviceDirectoryCleanerTest (Line 21)
- ProjectDirectoryBuilderTest (Line 23)
- MicroserviceProjectWriterTest (Line 47)
- GenerateInsertControllerTest (Line 153)
- GenerateInsertDAOTest (Line 95)
- GenerateInsertDTOTest (Line 122)
- MicroServiceGeneratorTest (Line 249)

🤖 Generated with [Claude Code](https://claude.com/claude-code)